### PR TITLE
Prevent launching help when F1 is pressed

### DIFF
--- a/js/main2e.js
+++ b/js/main2e.js
@@ -791,6 +791,7 @@ function _keydown(evt) {
     }
     if (evt.keyCode === 112) { // F1 - Reset
         cpu.reset();
+        evt.preventDefault(); // prevent launching help
     } else if (evt.keyCode === 113) { // F2 - Full Screen
         var elem = document.getElementById('screen');
         if (document.webkitCancelFullScreen) {


### PR DESCRIPTION
In some browsers, in particular Chrome OS, pressing F1 opens a help
screen. This can be suppressed by calling preventDefault() on the
event.