### PR TITLE
Match the location of the Alt key to the activated Apple key

### DIFF
--- a/js/main2e.js
+++ b/js/main2e.js
@@ -823,7 +823,11 @@ function _keydown(evt) {
     } else if (evt.keyCode == 91 || evt.keyCode == 93) { // Command
         keyboard.commandKey(true);
     } else if (evt.keyCode == 18) { // Alt
-        keyboard.optionKey(true);
+        if (evt.originalEvent.location == 1) {
+            keyboard.commandKey(true);
+        } else {
+            keyboard.optionKey(true);
+        }
     }
 }
 
@@ -838,7 +842,11 @@ function _keyup(evt) {
     } else if (evt.keyCode == 91 || evt.keyCode == 93) { // Command
         keyboard.commandKey(false);
     } else if (evt.keyCode == 18) { // Alt
-        keyboard.optionKey(false);
+        if (evt.originalEvent.location == 1) {
+            keyboard.commandKey(false);
+        } else {
+            keyboard.optionKey(false);
+        }
     }
 }
 


### PR DESCRIPTION
Modern browsers set the 'location' property on keyboard events when
the key is located in several places. The ALT key, for example, can be
either on the left or the right side of the keyboard.

This change uses the location to determine which Apple key to
activate, if it is available, and defaults to the old behavior if not.