### PR TITLE
Remediate NPM Advisory 1164

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-jest": "^24.5.0",
     "eslint": "^5.16.0",
     "jest": "^24.8.0",
+    "handlebars": "^4.3.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1"


### PR DESCRIPTION
After running `npm install`, npm warns of a severe security vulnerability: https://www.npmjs.com/advisories/1164.

This change to `package.json` ensures the version of handlebars that is installed (because of jest) is unaffected.

This can be removed once jest releases a newer version that requires an unaffected version of handlebars.