### PR TITLE
Fix bug where the alert dialog would not close

### DIFF
--- a/js/ui/apple2.js
+++ b/js/ui/apple2.js
@@ -232,6 +232,7 @@ export function doSave() {
     var name = document.querySelector('#save_name').value;
     saveLocalStorage(_currentDrive, name);
     MicroModal.close('save-modal');
+    window.setTimeout(() => openAlert('Saved'), 0);
 }
 
 export function doDelete(name) {
@@ -506,8 +507,6 @@ function saveLocalStorage(drive, name) {
     diskIndex[name] = json;
 
     window.localStorage.diskIndex = JSON.stringify(diskIndex);
-
-    openAlert('Saved');
 
     driveLights.label(drive, name);
     driveLights.dirty(drive, false);


### PR DESCRIPTION
Micromodal maintains a reference to the current open dialog in
this.modal. If one dialog is open while opening another, Micromodal
can get confused and maintain a reference to the wrong one.

One of the problems is that the close action is not instantaneous, so
even closing one dialog and opening another immediately after can
cause the problem.

This change adds a small delay before opening the alert dialog to work
around the problem.