### PR TITLE
Fix a problem where sometimes the emulator would run too fast

### DIFF
--- a/js/apple2.js
+++ b/js/apple2.js
@@ -67,6 +67,11 @@ export function Apple2(options) {
         window.webkitCancelAnimationFrame ||
         window.msCancelAnimationFrame;
 
+    /**
+     * Runs the emulator. If the emulator is already running, this does
+     * nothing. When this function exits either `runTimer` or
+     * `runAnimationFrame` will be non-null.
+     */
     function run() {
         if (runTimer || runAnimationFrame) {
             return; // already running
@@ -125,7 +130,7 @@ export function Apple2(options) {
             }
         };
         if (_requestAnimationFrame) {
-            _requestAnimationFrame(runFn);
+            runAnimationFrame = _requestAnimationFrame(runFn);
         } else {
             runTimer = setInterval(runFn, interval);
         }


### PR DESCRIPTION
Before, when using `requestAnimationFrame`, the emulator did not save
the id returned by the browser. This broke the invariant of `run`,
namely that on exit either `runAnimationFrame` or `runTimer` would be
set. This meant that sometimes when the emulator restarted, there
would be two callbacks to `requetsAnimationFrame` run on every frame.

Now the id is saved correctly and the invariant of `run` is maintained.