### PR TITLE
Track raw parallel port output and allow it to be downloaded

### DIFF
--- a/apple2js.html
+++ b/apple2js.html
@@ -348,6 +348,7 @@
           <div class="paper"></div>
         </main>
         <footer class="modal__footer">
+          <a id="raw_printer_output" class="button">Download Raw Output</a>
           <button class="modal__btn" onclick="Apple2.clearPrinterPaper()" aria-label="Clear the paper">Clear</button>
           <button class="modal__btn" data-micromodal-close aria-label="Close this dialog window">Close</button>
         </footer>

--- a/apple2jse.html
+++ b/apple2jse.html
@@ -353,6 +353,7 @@
           <div class="paper"></div>
         </main>
         <footer class="modal__footer">
+          <a id="raw_printer_output" class="button">Download Raw Output</a>
           <button class="modal__btn" onclick="Apple2.clearPrinterPaper()" aria-label="Clear the paper">Clear</button>
           <button class="modal__btn" data-micromodal-close aria-label="Close this dialog window">Close</button>
         </footer>

--- a/js/ui/apple2.js
+++ b/js/ui/apple2.js
@@ -766,6 +766,13 @@ export function openOptions() {
 }
 
 export function openPrinterModal() {
+    let mimeType = 'application/octet-stream';
+    let data = _printer.getRawOutput();
+    let a = document.querySelector('#raw_printer_output');
+
+    let blob = new Blob([data], { 'type': mimeType});
+    a.href = window.URL.createObjectURL(blob);
+    a.download = 'raw_printer_output.bin';
     MicroModal.show('printer-modal');
 }
 

--- a/js/ui/printer.js
+++ b/js/ui/printer.js
@@ -27,6 +27,8 @@ export default function Printer(el) {
     var paper = document.querySelector(el);
     var _lineBuffer = '';
     var _line;
+    var _rawLen = 0;
+    var _raw = new Uint8Array(1024);
 
     function newLine() {
         _line = document.createElement('div');
@@ -56,16 +58,29 @@ export default function Printer(el) {
                 _lineBuffer += c;
             }
             _line.innerText = _lineBuffer;
+            _raw[_rawLen] = val;
+            _rawLen++;
+            if (_rawLen > _raw.length) {
+                let newRaw = new Uint8Array(_raw.length * 2);
+                newRaw.set(_raw);
+                _raw = newRaw;
+            }
         },
 
         clear: function() {
             _lineBuffer = '';
             paper.innerHTML = "";
             newLine();
+            _raw = new Uint8Array(1024);
+            _rawLen = 0;
         },
 
         hasPrintout: function() {
             return paper.text.length;
+        },
+
+        getRawOutput: function() {
+            return _raw.slice(0, _rawLen);
         }
     };
 }


### PR DESCRIPTION
This change adds a download link to the printer dialog. The contents
of the download will be the raw bytes written to the parallel
interface. Note that often these bytes will have the high-bit set
causing the contents to look like gibberish.

However, this is extremely handy because it allows one to turn the
printer output into a PDF:

1.  In Appleworks (for example) configure an Apple ImageWriter in slot
    1 and print a file.
2.  Download the printer output.
3.  Download the header file from https://github.com/AppleWin/AppleWin/files/1168047/ImageWriterEmulator-NoLF.ps.txt
4.  In Linux, run:
    ```shell
    $ cat ImageWriterEmulator-NoLF.ps.txt raw_printer_output.bin | ps2pdf - printer_output.pdf
    ```

Note that the parallel port emulation in apple2js does not yet support
Print Shop, so I haven't been able to test that out.