### PR TITLE
Fix calls to cpu.cycles() and cpu.sync()

### DIFF
--- a/js/apple2io.js
+++ b/js/apple2io.js
@@ -89,7 +89,7 @@ export default function Apple2IO(cpu, vm)
     }
 
     function _tick() {
-        var now = cpu.cycles();
+        var now = cpu.getCycles();
         var phase = _didAudio ? (_phase > 0 ? _high : _low) : 0.0;
         for (; _sampleTime < now; _sampleTime += _cycles_per_sample) {
             _sample[_sampleIdx++] = phase;
@@ -117,7 +117,7 @@ export default function Apple2IO(cpu, vm)
 
     function _access(off, val) {
         var result = 0;
-        var now = cpu.cycles();
+        var now = cpu.getCycles();
         var delta = now - _trigger;
         switch (off) {
         case LOC.CLRTEXT:
@@ -259,7 +259,7 @@ export default function Apple2IO(cpu, vm)
                 // I/O Strobe
                 break;
             case LOC.PDLTRIG: // C07x
-                _trigger = cpu.cycles();
+                _trigger = cpu.getCycles();
                 break;
             }
         }
@@ -463,7 +463,7 @@ export default function Apple2IO(cpu, vm)
         },
 
         cycles: function apple2io_cycles() {
-            return cpu.cycles();
+            return cpu.getCycles();
         }
     };
 }

--- a/js/cards/smartport.js
+++ b/js/cards/smartport.js
@@ -266,7 +266,7 @@ export default function SmartPort(io, cpu, options ) {
             var blockOff = rom[0xff];
             var smartOff = blockOff + 3;
 
-            if (off === blockOff && cpu.sync()) { // Regular block device entry POINT
+            if (off === blockOff && cpu.getSync()) { // Regular block device entry POINT
                 _debug('block device entry');
                 cmd = cpu.read(0x00, COMMAND);
                 unit = cpu.read(0x00, UNIT);
@@ -301,7 +301,7 @@ export default function SmartPort(io, cpu, options ) {
                     formatDevice(state, unit);
                     break;
                 }
-            } else if (off == smartOff && cpu.sync()) {
+            } else if (off == smartOff && cpu.getSync()) {
                 _debug('smartport entry');
                 var retVal = {};
                 var stackAddr = new Address(state.sp + 1, 0x01);

--- a/js/cpu6502.ts
+++ b/js/cpu6502.ts
@@ -1273,11 +1273,11 @@ export default class CPU6502 {
         return results;
     }
 
-    public sync_() {
+    public getSync() {
         return this.sync;
     }
 
-    public cycles_() {
+    public getCycles() {
         return this.cycles;
     }
 

--- a/js/mmu.js
+++ b/js/mmu.js
@@ -698,8 +698,8 @@ export default function MMU(cpu, vm, lores1, lores2, hires1, hires2, io, rom)
             result = _80store ? 0x80 : 0x00;
             break;
         case LOC.VERTBLANK: // 0xC019
-            // result = cpu.cycles() % 20 < 5 ? 0x80 : 0x00;
-            result = (cpu.cycles() < _vbEnd) ? 0x80 : 0x00;
+            // result = cpu.getCycles() % 20 < 5 ? 0x80 : 0x00;
+            result = (cpu.getCycles() < _vbEnd) ? 0x80 : 0x00;
             break;
         case LOC.RDTEXT:
             result = vm.isText() ? 0x80 : 0x0;
@@ -758,7 +758,7 @@ export default function MMU(cpu, vm, lores1, lores2, hires1, hires2, io, rom)
             _writePages[page].write(page, off, val);
         },
         resetVB: function mmu_resetVB() {
-            _vbEnd = cpu.cycles() + 1000;
+            _vbEnd = cpu.getCycles() + 1000;
         },
         getState: function() {
             return {

--- a/js/ui/apple2.js
+++ b/js/ui/apple2.js
@@ -356,7 +356,7 @@ var showStats = 0;
 export function updateKHz() {
     var now = Date.now();
     var ms = now - startTime;
-    var cycles = cpu.cycles();
+    var cycles = cpu.getCycles();
     var delta;
     var fps;
     var khz;


### PR DESCRIPTION
Apparently, I broke everything when I removed the underscores from the
field names and added them to the method names. The fix is just to
rename the methods `getCycles` and `getSync` and call it a day.