### PR TITLE
Fix issue #64

### DIFF
--- a/js/cards/disk2.ts
+++ b/js/cards/disk2.ts
@@ -302,7 +302,7 @@ export default class DiskII implements Card {
     private writeMode = false;
     /** Whether the selected drive is on. */
     private on = false;
-    /** Current drive number (0, 1). */
+    /** Current drive number (1, 2). */
     private drive: DriveNumber = 1;
     /** Current drive object. */
     private cur = this.drives[this.drive - 1];
@@ -783,8 +783,8 @@ export default class DiskII implements Card {
         }
 
         Object.assign(cur, newDisk);
-        this.updateDirty(this.drive, false);
-        this.callbacks.label(this.drive, name);
+        this.updateDirty(drive, false);
+        this.callbacks.label(drive, name);
     }
 
     getJSON(drive: DriveNumber, pretty: boolean) {


### PR DESCRIPTION
During the typescriptification of `disk2.js`
(9d0ec5489c002834d71c68e0745ace3ae1d5336f), `drive`, a parameter
reference, was changed into `this.drive`, the current active disk, by
mistake. This change fixes that error.