### PR TITLE
Fix webpack ignored files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports =
         publicPath: '/dist/',
         watchContentBase: true,
         watchOptions: {
-            ignored: [/node_modules/, /\.git/]
+            ignored: ['**/node_modules/', '**/.git/']
         }
     },
     module: {


### PR DESCRIPTION
Before, the configuration used an array of regex literals. With
webpack 2.1.1, this breaks as it expects a list of glob strings.

See https://webpack.js.org/configuration/watch/#watchoptionsignored