### PR TITLE
Update webpack-dev-server to 4.0.0-beta1

### DIFF
--- a/js/entry2.js
+++ b/js/entry2.js
@@ -1,3 +1,5 @@
-var Apple2 = require('./main2');
+import { apple2 as _apple2 } from './main2';
+import * as UI from './ui/apple2';
 
-module.exports = { Apple2: Apple2 };
+export const Apple2 = UI;
+export const apple2 = _apple2;

--- a/js/entry2e.js
+++ b/js/entry2e.js
@@ -1,3 +1,5 @@
-var Apple2 = require('./main2e');
+import { apple2 as _apple2 } from './main2e';
+import * as UI from './ui/apple2';
 
-module.exports = { Apple2: Apple2 };
+export const Apple2 = UI;
+export const apple2 = _apple2;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.1.3",
     "webpack": "^5.28.0",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^4.0.0-beta.1"
   },
   "dependencies": {
     "apple2shader": "whscullin/apple2shader#f42252d8c2ad7055e3e5f5c39e235a710804e7a6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,23 +3,31 @@ const path = require('path');
 module.exports =
 {
     devtool: 'source-map',
+    mode: 'development',
     entry: {
         main2: path.resolve('js/entry2.js'),
         main2e: path.resolve('js/entry2e.js')
     },
     output: {
         path: path.resolve('dist/'),
-        library: 'Apple2',
-        libraryExport: 'Apple2',
-        libraryTarget: 'var'
+        library: {
+            name: 'Apple2',
+            type: 'umd',
+            export: 'Apple2',
+        },
     },
     devServer: {
         compress: true,
-        publicPath: '/dist/',
-        watchContentBase: true,
-        watchOptions: {
-            ignored: ['**/node_modules/', '**/.git/']
-        }
+        static: {
+            watch: false,
+            directory: __dirname,
+        },
+        dev: {
+            publicPath: '/dist/',
+        },
+        // watchContentBase: true,
+        // watchOptions: {
+        //     ignored: ['**/node_modules/', '**/.git/']
     },
     module: {
         rules: [


### PR DESCRIPTION
When using the old webpack-dev-server with webpack 5+, we get bitten
by webpack/webpack-dev-server#2692. This upgrades to 4.0.0-beta1 which
also (unhelpfully) changes the config options.  The `watchContentBase`
and `watchOptions` don't seem to have analogs in the new versions, but
I left them commented out for future reference.

Also, this does not update `package-lock.json` because even just
updating locally gave different output since I'm on a different
version of node, I'm guessing.