### PR TITLE
Use AudioWorklet where available

### DIFF
--- a/js/ui/apple2.ts
+++ b/js/ui/apple2.ts
@@ -82,6 +82,8 @@ let io: Apple2IO;
 let _currentDrive: DriveNumber = 1;
 let _e: boolean;
 
+let ready: Promise<[void, void]>;
+
 export const driveLights = new DriveLights();
 
 export function dumpAppleSoftProgram() {
@@ -213,7 +215,7 @@ function loadingStop() {
     MicroModal.close('loading-modal');
 
     if (!paused) {
-        _apple2.ready.then(() => {
+        ready.then(() => {
             _apple2.run();
         }).catch(console.error);
     }
@@ -762,7 +764,7 @@ export function updateUI() {
 export function pauseRun() {
     const label = document.querySelector<HTMLElement>('#pause-run i')!;
     if (paused) {
-        _apple2.ready.then(() => {
+        ready.then(() => {
             _apple2.run();
         }).catch(console.error);
         label.classList.remove('fa-play');
@@ -831,6 +833,8 @@ function onLoaded(apple2: Apple2, disk2: DiskII, smartPort: SmartPort, printer: 
     optionsModal.addOptions(audio);
     initSoundToggle();
 
+    ready = Promise.all([audio.ready, apple2.ready]);
+
     MicroModal.init();
 
     keyboard = new KeyBoard(cpu, io, e);
@@ -859,7 +863,7 @@ function onLoaded(apple2: Apple2, disk2: DiskII, smartPort: SmartPort, printer: 
         event.preventDefault();
     });
 
-    window.addEventListener('copy', (event) => {
+    window.addEventListener('copy', (event: Event) => {
         event.clipboardData!.setData('text/plain', vm.getText());
         event.preventDefault();
     });
@@ -879,7 +883,7 @@ function onLoaded(apple2: Apple2, disk2: DiskII, smartPort: SmartPort, printer: 
         _apple2.stop();
         processHash(hash);
     } else {
-        _apple2.ready.then(() => {
+        ready.then(() => {
             _apple2.run();
         }).catch(console.error);
     }

--- a/js/ui/audio.ts
+++ b/js/ui/audio.ts
@@ -54,8 +54,8 @@ export class Audio implements OptionHandler {
                     this.workletNode = new AudioWorkletNode(this.audioContext, 'audio_worker');
 
                     io.sampleRate(this.audioContext.sampleRate, QUANTUM_SIZE);
-                    io.addSampleListener((sample: number[]) => {
-                        if (this.sound) {
+                    io.addSampleListener((sample) => {
+                        if (this.sound && this.audioContext.state === 'running') {
                             this.workletNode.port.postMessage(sample);
                         }
                     });
@@ -88,8 +88,8 @@ export class Audio implements OptionHandler {
 
             this.audioNode.connect(this.audioContext.destination);
             io.sampleRate(this.audioContext.sampleRate, SAMPLE_SIZE);
-            io.addSampleListener((sample: number[]) => {
-                if (this.sound) {
+            io.addSampleListener((sample) => {
+                if (this.sound && this.audioContext.state === 'running') {
                     if (this.samples.length < 5) {
                         this.samples.push(sample);
                     }
@@ -106,7 +106,6 @@ export class Audio implements OptionHandler {
 
         debug('Sound initialized');
     }
-
 
     autoStart = () => {
         if (this.audioContext && !this.started) {

--- a/js/ui/audio_worker.ts
+++ b/js/ui/audio_worker.ts
@@ -1,0 +1,47 @@
+
+declare global {
+    interface AudioWorkletProcessor {
+        readonly port: MessagePort;
+        process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Map<string, Float32Array>): void;
+    }
+
+    const AudioWorkletProcessor: {
+        prototype: AudioWorkletProcessor;
+        new(options?: AudioWorkletNodeOptions): AudioWorkletProcessor;
+    };
+
+    function registerProcessor(name: string, ctor :{ new(): AudioWorkletProcessor; }): void
+}
+
+export class AppleAudioProcessor extends AudioWorkletProcessor {
+    private samples: Float32Array[] = []
+
+    constructor() {
+        super();
+        console.info('AppleAudioProcessor constructor');
+        this.port.onmessage = (ev: MessageEvent) => {
+            this.samples.push(ev.data);
+            if (this.samples.length > 256) {
+                this.samples.shift();
+            }
+        };
+    }
+
+    static get parameterDescriptors() {
+        return [];
+    }
+
+    process(_inputList: Float32Array[][], outputList: Float32Array[][], _parameters: Map<string, Float32Array>) {
+        const sample = this.samples.shift();
+        const output = outputList[0];
+        if (sample) {
+            for (let idx = 0; idx < sample.length; idx++) {
+                output[0][idx] = sample[idx];
+            }
+        }
+
+        return true;
+    }
+}
+
+registerProcessor('audio_worker', AppleAudioProcessor);

--- a/js/ui/audio_worker.ts
+++ b/js/ui/audio_worker.ts
@@ -1,3 +1,13 @@
+/* Copyright 2021 Will Scullin <scullin@scullinsteel.com>
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation.  No representations are made about the suitability of this
+ * software for any purpose.  It is provided "as is" without express or
+ * implied warranty.
+ */
 
 declare global {
     interface AudioWorkletProcessor {
@@ -40,6 +50,7 @@ export class AppleAudioProcessor extends AudioWorkletProcessor {
             }
         }
 
+        // Keep alive indefinitely.
         return true;
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,53 +1,10 @@
 const path = require('path');
 
-module.exports =
-{
+const baseConfig = {
     devtool: 'source-map',
     mode: 'development',
-    entry: {
-        main2: path.resolve('js/entry2.js'),
-        main2e: path.resolve('js/entry2e.js')
-    },
-    output: {
-        path: path.resolve('dist/'),
-        filename: '[name].bundle.js',
-        chunkFilename: '[name].bundle.js',
-        library: {
-            name: 'Apple2',
-            type: 'umd',
-            export: 'Apple2',
-        },
-    },
-    devServer: {
-        compress: true,
-        static: {
-            watch: {
-                ignored: /(node_modules|test|\.git)/
-            },
-            directory: __dirname,
-        },
-        dev: {
-            publicPath: '/dist/',
-        },
-    },
     module: {
         rules: [
-            {
-                test: /\.2mg$/i,
-                use: [
-                    {
-                        loader: 'file-loader',
-                    },
-                ],
-            },
-            {
-                test: /\.rom$/i,
-                use: [
-                    {
-                        loader: 'raw-loader',
-                    },
-                ],
-            },
             {
                 test: /\.ts$/i,
                 use: [
@@ -63,3 +20,48 @@ module.exports =
         extensions: ['.ts', '.js'],
     },
 };
+
+module.exports = [
+    {
+        ...baseConfig,
+        entry: {
+            main2: path.resolve('js/entry2.js'),
+            main2e: path.resolve('js/entry2e.js')
+        },
+        output: {
+            path: path.resolve('dist/'),
+            filename: '[name].bundle.js',
+            chunkFilename: '[name].bundle.js',
+            library: {
+                name: 'Apple2',
+                type: 'umd',
+                export: 'Apple2',
+            },
+        },
+        devServer: {
+            compress: true,
+            static: {
+                watch: {
+                    ignored: /(node_modules|test|\.git)/
+                },
+                directory: __dirname,
+            },
+            dev: {
+                publicPath: '/dist/',
+            },
+        },
+    },
+    {
+        ...baseConfig,
+        target: false,
+        entry: {
+            audio_worker: path.resolve('js/ui/audio_worker.ts')
+        },
+        output: {
+            publicPath: '/dist/',
+            path: path.resolve('dist/'),
+            filename: '[name].bundle.js',
+            globalObject: 'globalThis',
+        },
+    },
+];


### PR DESCRIPTION
Two big issues were that TypeScript does not include the appropriate types, and figuring out what Webpack incantation to not have it fill the worker with framework that doesn't work in an AudioWorkletGlobalContext, which has no `this` or `self`. Other than that, actually using it is pretty simple.