### PR TITLE
Keep track of disk sides

### DIFF
--- a/js/formats/create_disk.ts
+++ b/js/formats/create_disk.ts
@@ -55,10 +55,10 @@ export function createDiskFromJsonDisk(disk: JSONDisk): FloppyDisk | null {
             for (let t = 0; t < disk.data.length; t++) {
                 trackData[t] = [];
                 if (fmt == 'nib') {
-                    trackData[t][0] = base64_decode(disk.data[t] as string);
+                    trackData[t][0] = base64_decode(disk.data[t] as unknown as string);
                 } else {
                     for (let s = 0; s < disk.data[t].length; s++) {
-                        trackData[t][s] = base64_decode(disk.data[t][s] as string);
+                        trackData[t][s] = base64_decode(disk.data[t][s]);
                     }
                 }
             }

--- a/js/formats/create_disk.ts
+++ b/js/formats/create_disk.ts
@@ -46,6 +46,7 @@ export function createDiskFromJsonDisk(disk: JSONDisk): FloppyDisk | null {
     const fmt = disk.type;
     const readOnly = disk.readOnly;
     const name = disk.name;
+    const side = disk.disk;
 
     if (includes(NIBBLE_FORMATS, fmt)) {
         let trackData: memory[][];
@@ -71,6 +72,7 @@ export function createDiskFromJsonDisk(disk: JSONDisk): FloppyDisk | null {
             volume,
             readOnly,
             name,
+            side,
             data: trackData
         } as DiskOptions;
 

--- a/js/formats/create_disk.ts
+++ b/js/formats/create_disk.ts
@@ -54,8 +54,8 @@ export function createDiskFromJsonDisk(disk: JSONDisk): FloppyDisk | null {
             trackData = [];
             for (let t = 0; t < disk.data.length; t++) {
                 trackData[t] = [];
-                if (fmt == 'nib') {
-                    trackData[t][0] = base64_decode(disk.data[t] as unknown as string);
+                if (disk.type === 'nib') {
+                    trackData[t][0] = base64_decode(disk.data[t]);
                 } else {
                     for (let s = 0; s < disk.data[t].length; s++) {
                         trackData[t][s] = base64_decode(disk.data[t][s]);

--- a/js/formats/d13.ts
+++ b/js/formats/d13.ts
@@ -18,11 +18,12 @@ import { NibbleDisk, DiskOptions, ENCODING_NIBBLE } from './types';
  * @returns A nibblized disk
  */
 export default function createDiskFromDOS13(options: DiskOptions) {
-    const { data, name, rawData, volume, readOnly } = options;
+    const { data, name, side, rawData, volume, readOnly } = options;
     const disk: NibbleDisk = {
         format: 'd13',
         encoding: ENCODING_NIBBLE,
         name,
+        side,
         volume,
         readOnly,
         tracks: []

--- a/js/formats/do.ts
+++ b/js/formats/do.ts
@@ -20,11 +20,12 @@ import { NibbleDisk, DiskOptions, ENCODING_NIBBLE } from './types';
  * @returns A nibblized disk
  */
 export default function createDiskFromDOS(options: DiskOptions): NibbleDisk {
-    const { data, name, rawData, volume, readOnly } = options;
+    const { data, name, side, rawData, volume, readOnly } = options;
     const disk: NibbleDisk = {
         format: 'dsk',
         encoding: ENCODING_NIBBLE,
         name,
+        side,
         volume,
         readOnly,
         tracks: [],

--- a/js/formats/nib.ts
+++ b/js/formats/nib.ts
@@ -18,11 +18,12 @@ import { memory } from '../types';
  * @returns A nibblized disk
  */
 export default function createDiskFromNibble(options: DiskOptions): NibbleDisk {
-    const { data, name, rawData, volume, readOnly } = options;
+    const { data, name, side, rawData, volume, readOnly } = options;
     const disk: NibbleDisk = {
         format: 'nib',
         encoding: ENCODING_NIBBLE,
         name,
+        side,
         volume: volume || 254,
         readOnly: readOnly || false,
         tracks: []

--- a/js/formats/po.ts
+++ b/js/formats/po.ts
@@ -20,11 +20,12 @@ import { NibbleDisk, DiskOptions, ENCODING_NIBBLE } from './types';
  * @returns A nibblized disk
  */
 export default function createDiskFromProDOS(options: DiskOptions) {
-    const { data, name, rawData, volume, readOnly } = options;
+    const { data, name, side, rawData, volume, readOnly } = options;
     const disk: NibbleDisk = {
         format: 'nib',
         encoding: ENCODING_NIBBLE,
         name,
+        side,
         volume: volume || 254,
         tracks: [],
         readOnly: readOnly || false,

--- a/js/formats/types.ts
+++ b/js/formats/types.ts
@@ -107,12 +107,23 @@ export class JSONDiskBase {
 }
 
 /**
- * JSON Disk format with base64 encoded tracks
+ * JSON Disk format with base64 encoded tracks with sectors
  */
 
 export interface Base64JSONDisk extends JSONDiskBase {
+    type: Exclude<DiskFormat, 'nib'>
     encoding: 'base64'
     data: string[][]
+}
+
+/**
+ * JSON Disk format with base64 encoded nibblized tracks
+ */
+
+export interface Base64JSONNibbleDisk extends JSONDiskBase {
+    type: 'nib'
+    encoding: 'base64'
+    data: string[]
 }
 
 /**
@@ -120,6 +131,7 @@ export interface Base64JSONDisk extends JSONDiskBase {
  */
 
 export interface BinaryJSONDisk extends JSONDiskBase {
+    type: DiskFormat
     encoding: 'binary'
     data: memory[][]
 }
@@ -128,7 +140,7 @@ export interface BinaryJSONDisk extends JSONDiskBase {
  * General JSON Disk format
  */
 
-export type JSONDisk = Base64JSONDisk | BinaryJSONDisk;
+export type JSONDisk = Base64JSONDisk | Base64JSONNibbleDisk | BinaryJSONDisk;
 
 /**
  * Process Disk message payloads for worker

--- a/js/formats/types.ts
+++ b/js/formats/types.ts
@@ -101,9 +101,8 @@ export class JSONDiskBase {
     name: string
     disk?: string
     category?: string
-    writeProtected?: boolean
-    volume: byte
-    readOnly: boolean
+    volume?: byte
+    readOnly?: boolean
     gamepad?: GamepadConfiguration
 }
 
@@ -113,7 +112,7 @@ export class JSONDiskBase {
 
 export interface Base64JSONDisk extends JSONDiskBase {
     encoding: 'base64'
-    data: string[]
+    data: string[][]
 }
 
 /**

--- a/js/formats/types.ts
+++ b/js/formats/types.ts
@@ -21,6 +21,7 @@ export type DriveNumber = MemberOf<typeof DRIVE_NUMBERS>;
 
 export interface DiskOptions {
     name: string
+    side?: string
     volume: byte
     readOnly: boolean
     data?: memory[][]
@@ -35,6 +36,7 @@ export interface DiskOptions {
 
 export interface Disk {
     name: string
+    side?: string
     readOnly: boolean
 }
 
@@ -97,7 +99,7 @@ export type DiskFormat = MemberOf<typeof DISK_FORMATS>;
 export class JSONDiskBase {
     type: DiskFormat
     name: string
-    disk?: number
+    disk?: string
     category?: string
     writeProtected?: boolean
     volume: byte

--- a/js/formats/woz.ts
+++ b/js/formats/woz.ts
@@ -306,7 +306,7 @@ export default function createDiskFromWoz(options: DiskOptions): WozDisk {
         rawTracks: trks?.rawTracks || [],
         readOnly: true, //chunks.info.writeProtected === 1;
         name: meta?.values['title'] || options.name,
-        side: meta?.values['side_label'] || meta?.values['side'],
+        side: meta?.values['side_name'] || meta?.values['side'],
     };
 
     return disk;

--- a/js/formats/woz.ts
+++ b/js/formats/woz.ts
@@ -297,13 +297,16 @@ export default function createDiskFromWoz(options: DiskOptions): WozDisk {
 
     debug(chunks);
 
+    const { meta, tmap, trks } = chunks;
+
     const disk: WozDisk = {
         encoding: ENCODING_BITSTREAM,
-        trackMap: chunks.tmap?.trackMap || [],
-        tracks: chunks.trks?.tracks || [],
-        rawTracks: chunks.trks?.rawTracks || [],
+        trackMap: tmap?.trackMap || [],
+        tracks: trks?.tracks || [],
+        rawTracks: trks?.rawTracks || [],
         readOnly: true, //chunks.info.writeProtected === 1;
-        name: chunks.meta?.values['title'] || options.name
+        name: meta?.values['title'] || options.name,
+        side: meta?.values['side_label'] || meta?.values['side'],
     };
 
     return disk;

--- a/js/ui/apple2.ts
+++ b/js/ui/apple2.ts
@@ -844,7 +844,8 @@ function gup(name: string) {
 /** Returns the URL fragment. */
 function hup() {
     const regex = new RegExp('#(.*)');
-    const results = regex.exec(window.location.hash);
+    const hash = decodeURIComponent(window.location.hash);
+    const results = regex.exec(hash);
     if (!results)
         return '';
     else

--- a/js/ui/drive_lights.ts
+++ b/js/ui/drive_lights.ts
@@ -14,11 +14,11 @@ export default class DriveLights implements Callbacks {
         // document.querySelector('#disksave' + drive).disabled = !dirty;
     }
 
-    public label(drive: DriveNumber, label?: string) {
+    public label(drive: DriveNumber, label?: string, side?: string) {
         const labelElement =
             document.querySelector('#disk-label' + drive)! as HTMLElement;
         if (label) {
-            labelElement.innerText = label;
+            labelElement.innerText = label + (side ? ` - ${side}` : '');
         }
         return labelElement.innerText;
     }

--- a/json/disks/index.js
+++ b/json/disks/index.js
@@ -1,15 +1,8 @@
 disk_index = [
   {
-    "filename": "json/disks/shell-shock-game.json",
-    "name": "Shell Shock",
-    "disk": "Game",
-    "category": "Game"
-  },
-  {
-    "filename": "json/disks/shell-shock-maps.json",
-    "name": "Shell Shock",
-    "disk": "Maps",
-    "category": "Game"
+    "filename": "json/disks/audit.json",
+    "name": "Apple II Audit",
+    "category": "Utility"
   },
   {
     "filename": "json/disks/dos33master.json",
@@ -20,10 +13,5 @@ disk_index = [
     "filename": "json/disks/prodos.json",
     "name": "ProDOS",
     "category": "System"
-  },
-  {
-    "filename": "json/disks/audit.json",
-    "name": "Apple II Audit",
-    "category": "Utility"
   }
 ];

--- a/json/disks/index.js
+++ b/json/disks/index.js
@@ -1,8 +1,15 @@
 disk_index = [
   {
-    "filename": "json/disks/audit.json",
-    "name": "Apple II Audit",
-    "category": "Utility"
+    "filename": "json/disks/shell-shock-game.json",
+    "name": "Shell Shock",
+    "disk": "Game",
+    "category": "Game"
+  },
+  {
+    "filename": "json/disks/shell-shock-maps.json",
+    "name": "Shell Shock",
+    "disk": "Maps",
+    "category": "Game"
   },
   {
     "filename": "json/disks/dos33master.json",
@@ -13,5 +20,10 @@ disk_index = [
     "filename": "json/disks/prodos.json",
     "name": "ProDOS",
     "category": "System"
+  },
+  {
+    "filename": "json/disks/audit.json",
+    "name": "Apple II Audit",
+    "category": "Utility"
   }
 ];

--- a/test/js/formats/create_disk.spec.ts
+++ b/test/js/formats/create_disk.spec.ts
@@ -1,0 +1,17 @@
+import { createDiskFromJsonDisk } from 'js/formats/create_disk';
+import { testDisk } from './testdata/json';
+
+describe('createDiskFromJsonDisk', () => {
+    it('parses a JSON disk', () => {
+        const disk = createDiskFromJsonDisk(testDisk);
+        expect(disk).toEqual({
+            encoding: 'nibble',
+            format: 'dsk',
+            name: 'Test Disk',
+            readOnly: undefined,
+            side: 'Front',
+            volume: 254,
+            tracks: expect.any(Array)
+        });
+    });
+});

--- a/test/js/formats/testdata/json.ts
+++ b/test/js/formats/testdata/json.ts
@@ -1,0 +1,22 @@
+import { base64_encode } from 'js/base64';
+import { JSONDisk } from 'js/formats/types';
+
+export const testDisk: JSONDisk = {
+    name: 'Test Disk',
+    disk: 'Front',
+    category: 'Test',
+    type: 'dsk',
+    encoding: 'base64',
+    data: []
+};
+
+const sector = new Uint8Array(256);
+sector.fill(0);
+
+for (let idx = 0; idx < 35; idx++) {
+    const track: string[] = [];
+    for (let jdx = 0; jdx < 16; jdx++) {
+        track.push(base64_encode(sector));
+    }
+    testDisk.data.push(track);
+}

--- a/test/js/formats/testdata/woz.ts
+++ b/test/js/formats/testdata/woz.ts
@@ -108,8 +108,8 @@ const mockTRKS2 = [
  * META structures
  */
 
-const mockMETA1 = 'title\tMock Woz 1';
-const mockMETA2 = 'title\tMock Woz 2';
+const mockMETA1 = 'title\tMock Woz 1\t';
+const mockMETA2 = 'title\tMock Woz 2\nside_name\tB';
 
 /**
  * Woz Version 1

--- a/test/js/formats/woz.spec.ts
+++ b/test/js/formats/woz.spec.ts
@@ -61,6 +61,7 @@ describe('woz', () => {
         const disk = createDiskFromWoz(options) as WozDisk;
         expect(disk).toEqual({
             name: 'Mock Woz 2',
+            side: 'B',
             readOnly: true,
             encoding: ENCODING_BITSTREAM,
             trackMap: mockTMAP,


### PR DESCRIPTION
Disk side information was being dropped and thus not displayable in the UI. This plumbs the value through various formats and adds some light testing.

Also fixes an issue where URL encoded hashes were not properly interpreted.