### PR TITLE
Support Tom Harte test suite

### DIFF
--- a/test/cpu-tom-harte.spec.ts
+++ b/test/cpu-tom-harte.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Uses test files from https://github.com/TomHarte/ProcessorTests
+ * To use set TOM_HARTE_TEST_PATH to local copy of that repository
+ */
+
+import fs from 'fs';
+
+import CPU6502 from 'js/cpu6502';
+import { toHex } from 'js/util';
+import type { byte, word } from 'js/types';
+
+import { toReadableState } from './util/cpu';
+import Debugger from 'js/debugger';
+import { TestMemory } from './util/memory';
+
+// JEST_DETAIL=true converts decimal values to hex before testing
+// expectations, for better readability at the expense of speed.
+const detail = !!process.env.JEST_DETAIL;
+
+/**
+ * Types for JSON tests
+ */
+interface TestState {
+    pc: word
+    s: byte
+    a: byte
+    x: byte
+    y: byte
+    p: byte
+    ram: [word, byte][]
+}
+
+interface Test {
+    name: string
+    initial: TestState
+    final: TestState
+    cycles: [word, byte, string][]
+}
+
+let memory: TestMemory;
+let debug: Debugger | null;
+let cpu: CPU6502;
+
+/**
+ * Initialize cpu and memory before test
+ *
+ * @param state Initial test state
+ */
+
+function initState(state: TestState) {
+    const { pc, s, a, x, y, p, ram } = state;
+    cpu.setState({ cycles: 0, pc, sp: s, a, x, y, s: p });
+
+    for (let idx = 0; idx < ram.length; idx++) {
+        const [address, mem] = ram[idx];
+        const off = address & 0xff;
+        const page = address >> 8;
+        cpu.write(page, off, mem);
+    }
+}
+
+/**
+ * Pretty print 'address: val' if detail is turned on
+ *
+ * @returns
+ */
+
+function toAddrValHex([address, val]: [word, byte]) {
+    if (detail) {
+        return `${toHex(address, 4)}: ${toHex(val)}`;
+    } else {
+        return [address, val];
+    }
+}
+
+/**
+ * Pretty print 'address: val (read|write)' if detail is turned on
+ *
+ * @returns
+ */
+
+function toAddrValHexType([address, val, type]: [word, byte, string]) {
+    if (detail) {
+        return `${toHex(address, 4)}: ${toHex(val)} ${type}`;
+    } else {
+        return [address, val, type];
+    }
+}
+
+/**
+ * Compare end state and read write behavior of test run
+ *
+ * @param state Expected state
+ * @param cycles Detailed read and write logging by cycle
+ */
+function expectState(state: TestState, cycles: [word, byte, string][]) {
+    const { pc, s, a, x, y, p, ram } = state;
+    expect(toReadableState(cpu.getState())).toEqual(
+        toReadableState({cycles: cycles.length, pc, sp: s, a, x, y, s: p }));
+
+    const result = [];
+    for (let idx = 0; idx < ram.length; idx++) {
+        const [address] = ram[idx];
+        const off = address & 0xff;
+        const page = address >> 8;
+        result.push([address, cpu.read(page, off), '']);
+    }
+    expect(result.map(toAddrValHex)).toEqual(ram.map(toAddrValHex));
+    expect(memory.getLog().map(toAddrValHexType)).toEqual(cycles.map(toAddrValHexType));
+}
+
+interface OpTest {
+    op: string
+    name: string
+    mode: string
+}
+
+const opAry6502: OpTest[] = [];
+const opAry65C02: OpTest[] = [];
+
+cpu = new CPU6502();
+
+// Grab the implemented op codes
+// TODO: Decide whether which undocumented opcodes are worthwhile.
+for (const op in cpu.OPS_6502) {
+    const { name, mode } = cpu.OPS_6502[op];
+    const test = { op: toHex(+op), name, mode };
+    opAry6502.push(test);
+    opAry65C02.push(test);
+}
+
+for (const op in cpu.OPS_65C02) {
+    const { name, mode } = cpu.OPS_65C02[op];
+    const test = { op: toHex(+op), name, mode };
+    opAry65C02.push(test);
+}
+const testPath = process.env.TOM_HARTE_TEST_PATH;
+
+const testPath6502 = `${testPath}/6502/v1/`;
+const testPath65C02 = `${testPath}/wdc65c02/v1/`;
+
+// There are 10,0000 tests per test file, which would take several hours
+// in jest. 16 is a manageable quantity that still gets good coverage.
+const maxTests = 16;
+
+if (testPath) {
+    describe('Tom Harte', function() {
+        describe('6502', function() {
+            beforeAll(function() {
+                cpu = new CPU6502();
+                memory = new TestMemory(256);
+                cpu.addPageHandler(memory);
+            });
+
+            describe.each(opAry6502)('Test op $op $name $mode', ({op}) => {
+                const data = fs.readFileSync(`${testPath6502}${op}.json`, 'utf-8');
+                const tests = JSON.parse(data) as Test[];
+
+                it.each(tests.slice(0, maxTests))('Test $name', ({ initial, final, cycles }) => {
+                    initState(initial);
+                    memory.logStart();
+                    cpu.step();
+                    memory.logStop();
+                    expectState(final, cycles);
+                });
+            });
+        });
+
+        describe('WDC 65C02', function() {
+            beforeAll(function() {
+                cpu = new CPU6502({ '65C02': true });
+                debug = new Debugger({
+                    getCPU: () => (cpu),
+                    run: () => {},
+                    stop: () => {},
+                });
+
+                // To get really verbose test logging comment out this line.
+                debug = null;
+
+                memory = new TestMemory(256);
+                cpu.addPageHandler(memory);
+            });
+
+            describe.each(opAry65C02)('Test op $op $name $mode', ({op}) => {
+                const data = fs.readFileSync(`${testPath65C02}${op}.json`, 'utf-8');
+                const tests = JSON.parse(data) as Test[];
+
+                it.each(tests.slice(0, maxTests))('Test $name', ({ initial, final, cycles }) => {
+                    initState(initial);
+                    if (debug) {
+                        console.info(initial, debug.dumpRegisters(), debug.dumpPC(initial.pc));
+                    }
+                    memory.logStart();
+                    cpu.step();
+                    memory.logStop();
+                    expectState(final, cycles);
+                });
+            });
+        });
+    });
+} else {
+    test('Skipping Tom Harte tests', () => { expect(testPath).toBeFalsy(); });
+}

--- a/test/cpu.spec.ts
+++ b/test/cpu.spec.ts
@@ -1,5 +1,5 @@
-
 import CPU6502 from '../js/cpu6502';
+// From https://github.com/Klaus2m5/6502_65C02_functional_tests
 import Test6502 from './roms/6502test';
 import Test65C02 from './roms/65C02test';
 

--- a/test/cpu6502.spec.ts
+++ b/test/cpu6502.spec.ts
@@ -1,21 +1,11 @@
-import CPU6502 from '../js/cpu6502';
+import CPU6502, { CpuState, flags } from '../js/cpu6502';
 import { TestMemory } from './util/memory';
 import { bios, Program } from './util/bios';
+import { toReadableState } from './util/cpu';
 
-var FLAGS = {
-    N: 0x80,       // Negative
-    V: 0x40,       // oVerflow
-    DEFAULT: 0x20, // Default
-    B: 0x10,       // Break
-    D: 0x08,       // Decimal
-    I: 0x04,       // Interrupt
-    Z: 0x02,       // Zero
-    C: 0x01        // Carry
-};
-
-var DEFAULT_STATE = {
+const DEFAULT_STATE: CpuState = {
     cycles: 0,
-    s: FLAGS.DEFAULT,
+    s: flags.X,
     sp: 0xff,
     a: 0x00,
     x: 0x00,
@@ -23,27 +13,27 @@ var DEFAULT_STATE = {
     pc: 0x0400
 };
 
-var memory;
-var cpu;
-var program;
+let memory;
+let cpu: CPU6502;
+let program;
 
-function initState(initialState) {
-    var state = Object.assign({}, DEFAULT_STATE, initialState);
+function initState(initialState: Partial<CpuState>) {
+    const state = {...DEFAULT_STATE, ...initialState};
     cpu.setState(state);
 }
 
-function expectState(initialState, expectedState) {
-    var state = Object.assign({}, initialState, expectedState);
-    expect(cpu.getState()).toEqual(state);
+function expectState(initialState: CpuState, expectedState: Partial<CpuState>) {
+    const state  = {...initialState, ...expectedState};
+    expect(toReadableState(cpu.getState())).toEqual(toReadableState(state));
 }
 
-function initMemory(memAry) {
-    for (var idx = 0; idx < memAry.length; idx++) {
-        var mem = memAry[idx];
-        var page = mem[0];
-        var off = mem[1];
-        var data = mem[2];
-        for (var jdx = 0; jdx < data.length; jdx++) {
+function initMemory(memAry: [page: number, off: number, data: number[]][]) {
+    for (let idx = 0; idx < memAry.length; idx++) {
+        const mem = memAry[idx];
+        let page = mem[0];
+        let off = mem[1];
+        const data = mem[2];
+        for (let jdx = 0; jdx < data.length; jdx++) {
             cpu.write(page, off++, data[jdx]);
             if (off > 0xff) {
                 page++;
@@ -53,15 +43,15 @@ function initMemory(memAry) {
     }
 }
 
-function expectMemory(expectAry) {
-    var memAry = [];
-    for (var idx = 0; idx < expectAry.length; idx++) {
-        var mem = expectAry[idx];
-        var page = mem[0];
-        var off = mem[1];
-        var expectData = mem[2];
-        var data = [];
-        for (var jdx = 0; jdx < expectData.length; jdx++) {
+function expectMemory(expectAry: [page: number, off: number, data: number[]][]) {
+    const memAry = [];
+    for (let idx = 0; idx < expectAry.length; idx++) {
+        const mem = expectAry[idx];
+        let page = mem[0];
+        let off = mem[1];
+        const expectData = mem[2];
+        const data = [];
+        for (let jdx = 0; jdx < expectData.length; jdx++) {
             data.push(cpu.read(page, off++));
             if (off > 0xff) {
                 page++;
@@ -73,16 +63,14 @@ function expectMemory(expectAry) {
     expect(memAry).toEqual(expectAry);
 }
 
-function expectStack(expectAry) {
-    var state = cpu.getState();
+function expectStack(expectAry: number[]) {
+    const state = cpu.getState();
     expectMemory([[0x01, state.sp + 1, expectAry]]);
 }
 
-function testCode(code, steps, setupState, expectedState) {
-    var initialState = Object.assign({}, DEFAULT_STATE, setupState);
-    var finalState = Object.assign({
-        pc: initialState.pc + code.length
-    }, expectedState);
+function testCode(code: number[], steps: number, setupState: Partial<CpuState>, expectedState: Partial<CpuState>) {
+    const initialState = {...DEFAULT_STATE, ...setupState};
+    const finalState =  { pc: initialState.pc + code.length, ...expectedState };
 
     program = new Program(0x04, code);
     cpu.addPageHandler(program);
@@ -115,7 +103,7 @@ describe('CPU6502', function() {
 
             expectState(DEFAULT_STATE, {
                 cycles: 5,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -123,13 +111,13 @@ describe('CPU6502', function() {
 
         it('should not irq if I set', function () {
             initState({
-                s: FLAGS.DEFAULT | FLAGS.I
+                s: flags.X | flags.I
             });
 
             cpu.irq();
 
             expectState(DEFAULT_STATE, {
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 pc: 0x400
             });
         });
@@ -139,7 +127,7 @@ describe('CPU6502', function() {
 
             expectState(DEFAULT_STATE, {
                 cycles: 5,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -156,7 +144,7 @@ describe('CPU6502', function() {
         it('should BRK', function () {
             testCode([0x00, 0x00], 1, {}, {
                 cycles: 7,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -168,7 +156,7 @@ describe('CPU6502', function() {
                 sp: 0xFC
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.N,
+                s: flags.X | flags.N,
                 sp: 0xFF,
                 pc: 0x1234
             });
@@ -274,57 +262,57 @@ describe('CPU6502', function() {
         it('should SEC', function () {
             testCode([0x38], 1, {}, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
         it('should CLC', function () {
             testCode([0x18], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
         it('should SEI', function () {
             testCode([0x78], 1, {}, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.I
+                s: flags.X | flags.I
             });
         });
 
         it('should CLI', function () {
             testCode([0x58], 1, {
-                s: FLAGS.DEFAULT | FLAGS.I
+                s: flags.X | flags.I
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
         it('should CLV', function () {
             testCode([0xB8], 1, {
-                s: FLAGS.DEFAULT | FLAGS.V
+                s: flags.X | flags.V
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
         it('should SED', function () {
             testCode([0xF8], 1, {}, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.D
             });
         });
 
         it('should CLD', function () {
             testCode([0xD8], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.D
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
     });
@@ -371,21 +359,21 @@ describe('CPU6502', function() {
 
         it('should PHP', function() {
             testCode([0x08], 1, {
-                s: FLAGS.DEFAULT | FLAGS.N | FLAGS.C
+                s: flags.X | flags.N | flags.C
             }, {
                 cycles: 3,
                 sp: 0xfe
             });
-            expectStack([FLAGS.DEFAULT | FLAGS.B | FLAGS.N | FLAGS.C]);
+            expectStack([flags.X | flags.B | flags.N | flags.C]);
         });
 
         it('should PLP', function() {
-            initMemory([[0x01, 0xff, [FLAGS.N | FLAGS.C]]]);
+            initMemory([[0x01, 0xff, [flags.N | flags.C]]]);
             testCode([0x28], 1, {
                 sp: 0xfe
             }, {
                 cycles: 4,
-                s: FLAGS.DEFAULT | FLAGS.N | FLAGS.C,
+                s: flags.X | flags.N | flags.C,
                 sp: 0xff
             });
         });
@@ -407,7 +395,7 @@ describe('CPU6502', function() {
             });
         });
 
-        it('should JMP (abs) across page boundries with bugs', function () {
+        it('should JMP (abs) across page boundaries with bugs', function () {
             initMemory([[0x02, 0xFF, [0x34, 0x12]],
                 [0x02, 0x00, [0xff]]]);
             testCode([0x6C, 0xFF, 0x02], 1, {}, {
@@ -441,7 +429,7 @@ describe('CPU6502', function() {
         // ********** bcs
         it('should BCS forward', function () {
             testCode([0xB0, 0x7F], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 3,
                 pc: 0x0481
@@ -450,7 +438,7 @@ describe('CPU6502', function() {
 
         it('should BCS backward', function () {
             testCode([0xB0, 0xff], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 3,
                 pc: 0x0401
@@ -459,7 +447,7 @@ describe('CPU6502', function() {
 
         it('should BCS across pages with an extra cycle', function () {
             testCode([0xB0, 0xfd], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 4,
                 pc: 0x03FF
@@ -496,7 +484,7 @@ describe('CPU6502', function() {
 
         it('should not BCC if carry set', function () {
             testCode([0x90, 0xfd], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 2,
                 pc: 0x0402
@@ -857,7 +845,7 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0xAA,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
@@ -867,7 +855,7 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x54,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
@@ -876,7 +864,7 @@ describe('CPU6502', function() {
             testCode([0x0E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
             expectMemory([[0x03, 0x33, [0xAA]]]);
         });
@@ -886,7 +874,7 @@ describe('CPU6502', function() {
             testCode([0x0E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
             expectMemory([[0x03, 0x33, [0x54]]]);
         });
@@ -898,7 +886,7 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0xAA,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
@@ -908,18 +896,18 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x54,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
         it('should ROL A with carry in', function () {
             testCode([0x2A], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0xAA
             }, {
                 cycles: 2,
                 a: 0x55,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
@@ -928,7 +916,7 @@ describe('CPU6502', function() {
             testCode([0x2E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
             expectMemory([[0x03, 0x33, [0xAA]]]);
         });
@@ -938,7 +926,7 @@ describe('CPU6502', function() {
             testCode([0x2E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
             expectMemory([[0x03, 0x33, [0x54]]]);
         });
@@ -946,10 +934,10 @@ describe('CPU6502', function() {
         it('should ROL abs with carry in', function () {
             initMemory([[0x03, 0x33, [0xAA]]]);
             testCode([0x2E, 0x33, 0x03], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
             expectMemory([[0x03, 0x33, [0x55]]]);
         });
@@ -970,7 +958,7 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x2A,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
@@ -988,7 +976,7 @@ describe('CPU6502', function() {
             testCode([0x4E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
             expectMemory([[0x03, 0x33, [0x2A]]]);
         });
@@ -1008,18 +996,18 @@ describe('CPU6502', function() {
                 a: 0x55
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0x2A
             });
         });
 
         it('should ROR A with carry in', function () {
             testCode([0x6A], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0x55
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C | FLAGS.N,
+                s: flags.X | flags.C | flags.N,
                 a: 0xAA
             });
         });
@@ -1038,7 +1026,7 @@ describe('CPU6502', function() {
             testCode([0x6E, 0x33, 0x03], 1, {
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
             expectMemory([[0x03, 0x33, [0x2A]]]);
         });
@@ -1046,10 +1034,10 @@ describe('CPU6502', function() {
         it('should ROR abs with carry in', function () {
             initMemory([[0x03, 0x33, [0x55]]]);
             testCode([0x6E, 0x33, 0x03], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.C | FLAGS.N
+                s: flags.X | flags.C | flags.N
             });
             expectMemory([[0x03, 0x33, [0xAA]]]);
         });
@@ -1070,7 +1058,7 @@ describe('CPU6502', function() {
                 a: 0xA0
             }, {
                 cycles: 4,
-                s: FLAGS.DEFAULT | FLAGS.N,
+                s: flags.X | flags.N,
                 a: 0xF5
             });
         });
@@ -1081,7 +1069,7 @@ describe('CPU6502', function() {
                 a: 0xA5
             }, {
                 cycles: 4,
-                s: FLAGS.DEFAULT | FLAGS.N,
+                s: flags.X | flags.N,
                 a: 0xF0
             });
         });
@@ -1092,7 +1080,7 @@ describe('CPU6502', function() {
                 a: 0x55
             }, {
                 cycles: 3,
-                s: FLAGS.DEFAULT | FLAGS.V
+                s: flags.X | flags.V
             });
         });
 
@@ -1101,7 +1089,7 @@ describe('CPU6502', function() {
             testCode([0x2C, 0x33, 0x03], 1, {
             }, {
                 cycles: 4,
-                s: FLAGS.DEFAULT | FLAGS.N | FLAGS.Z
+                s: flags.X | flags.N | flags.Z
             });
         });
     });
@@ -1114,18 +1102,18 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x78,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
         it('should ADC with carry in', function () {
             testCode([0x69, 0x55], 1, {
                 a: 0x23,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             }, {
                 cycles: 2,
                 a: 0x79,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
@@ -1135,7 +1123,7 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x80,
-                s: FLAGS.DEFAULT | FLAGS.N | FLAGS.V
+                s: flags.X | flags.N | flags.V
             });
         });
 
@@ -1145,120 +1133,120 @@ describe('CPU6502', function() {
             }, {
                 cycles: 2,
                 a: 0x10,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
         // ********** ADC BCD
         it('should ADC BCD', function () {
             testCode([0x69, 0x16], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D,
+                s: flags.X | flags.D,
                 a: 0x25
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.V,
+                s: flags.X | flags.D,
                 a: 0x41
             });
         });
 
         it('should ADC BCD with carry in', function () {
             testCode([0x69, 0x55], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.C,
+                s: flags.X | flags.D | flags.C,
                 a: 0x23
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT| FLAGS.D  | FLAGS.V,
+                s: flags.X | flags.D,
                 a: 0x79
             });
         });
 
         it('should ADC BCD with carry out', function () {
             testCode([0x69, 0x10], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D,
+                s: flags.X | flags.D,
                 a: 0x91
             }, {
                 cycles: 2,
                 a: 0x01,
-                s: FLAGS.DEFAULT | FLAGS.D |  FLAGS.C
+                s: flags.X | flags.N | flags.D |  flags.C
             });
         });
 
         // ********** SBC
         it('should SBC', function () {
             testCode([0xE9, 0x23], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0x55
             }, {
                 cycles: 2,
                 a: 0x32,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
         it('should SBC with borrow in', function () {
             testCode([0xE9, 0x23], 1, {
-                s: FLAGS.DEFAULT,
+                s: flags.X,
                 a: 0x55
             }, {
                 cycles: 2,
                 a: 0x31,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
         it('should SBC with borrow out', function () {
             testCode([0xE9, 0x55], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0x23
             }, {
                 cycles: 2,
                 a: 0xCE,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
         it('should SBC with overflow out', function () {
             testCode([0xE9, 0x7F], 1, {
-                s: FLAGS.DEFAULT | FLAGS.C,
+                s: flags.X | flags.C,
                 a: 0xAF
             }, {
                 cycles: 2,
                 a: 0x30,
-                s: FLAGS.DEFAULT | FLAGS.V | FLAGS.C
+                s: flags.X | flags.V | flags.C
             });
         });
 
         // ********** SBC BCD
         it('should SBC BCD', function () {
             testCode([0xE9, 0x23], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.C,
+                s: flags.X | flags.D | flags.C,
                 a: 0x55
             }, {
                 cycles: 2,
                 a: 0x32,
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.C
+                s: flags.X | flags.D | flags.C
             });
         });
 
         it('should SBC BCD with borrow in', function () {
             testCode([0xE9, 0x23], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D,
+                s: flags.X | flags.D,
                 a: 0x55
             }, {
                 cycles: 2,
                 a: 0x31,
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.C
+                s: flags.X | flags.D | flags.C
             });
         });
 
         it('should SBC BCD with borrow out', function () {
             testCode([0xE9, 0x55], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D | FLAGS.C,
+                s: flags.X | flags.D | flags.C,
                 a: 0x23
             }, {
                 cycles: 2,
                 a: 0x68,
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.N | flags.D
             });
         });
 
@@ -1348,7 +1336,7 @@ describe('CPU6502', function() {
                 a: 0x33
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
@@ -1357,7 +1345,7 @@ describe('CPU6502', function() {
                 a: 0x44
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.Z | FLAGS.C
+                s: flags.X | flags.Z | flags.C
             });
         });
 
@@ -1366,7 +1354,7 @@ describe('CPU6502', function() {
                 a: 0x55
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
@@ -1376,7 +1364,7 @@ describe('CPU6502', function() {
                 x: 0x33
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
@@ -1385,7 +1373,7 @@ describe('CPU6502', function() {
                 x: 0x44
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.Z | FLAGS.C
+                s: flags.X | flags.Z | flags.C
             });
         });
 
@@ -1394,7 +1382,7 @@ describe('CPU6502', function() {
                 x: 0x55
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
 
@@ -1404,7 +1392,7 @@ describe('CPU6502', function() {
                 y: 0x33
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.N
+                s: flags.X | flags.N
             });
         });
 
@@ -1413,7 +1401,7 @@ describe('CPU6502', function() {
                 y: 0x44
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.Z | FLAGS.C
+                s: flags.X | flags.Z | flags.C
             });
         });
 
@@ -1422,7 +1410,7 @@ describe('CPU6502', function() {
                 y: 0x55
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.C
+                s: flags.X | flags.C
             });
         });
     });
@@ -1440,14 +1428,14 @@ describe('65c02', function() {
     describe('#signals', function() {
         it('should clear D on IRQ', function() {
             initState({
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.D
             });
 
             cpu.irq();
 
             expectState(DEFAULT_STATE, {
                 cycles: 5,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -1455,14 +1443,14 @@ describe('65c02', function() {
 
         it('should clear D on NMI', function() {
             initState({
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.D
             });
 
             cpu.nmi();
 
             expectState(DEFAULT_STATE, {
                 cycles: 5,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -1470,10 +1458,10 @@ describe('65c02', function() {
 
         it('should clear D on BRK', function () {
             testCode([0x00, 0x00], 1, {
-                s: FLAGS.DEFAULT | FLAGS.D
+                s: flags.X | flags.D
             }, {
                 cycles: 7,
-                s: FLAGS.DEFAULT | FLAGS.I,
+                s: flags.X | flags.I,
                 sp: 0xfc,
                 pc: 0xff00
             });
@@ -1620,11 +1608,11 @@ describe('65c02', function() {
     describe('#logical operators', function() {
         it('should BIT imm and effect other flags', function() {
             testCode([0x89, 0x33], 1, {
-                s: FLAGS.DEFAULT | FLAGS.N,
+                s: flags.X | flags.N,
                 a: 0x44
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT | FLAGS.Z | FLAGS.N
+                s: flags.X | flags.Z | flags.N
             });
         });
 
@@ -1633,7 +1621,7 @@ describe('65c02', function() {
                 a: 0x03
             }, {
                 cycles: 2,
-                s: FLAGS.DEFAULT
+                s: flags.X
             });
         });
 
@@ -1654,7 +1642,7 @@ describe('65c02', function() {
                 a: 0xAA
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.Z
+                s: flags.X | flags.Z
             });
             expectMemory([[0x00, 0x33, [0x00]]]);
         });
@@ -1676,7 +1664,7 @@ describe('65c02', function() {
                 a: 0xAA
             }, {
                 cycles: 6,
-                s: FLAGS.DEFAULT | FLAGS.Z
+                s: flags.X | flags.Z
             });
             expectMemory([[0x03, 0x33, [0xFF]]]);
         });
@@ -1759,7 +1747,7 @@ describe('65c02', function() {
         it('BBR0 should not branch if bit 0 set', function() {
             initMemory([[0x00, 0x33, [0x01]]]);
             testCode([0x0F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1767,7 +1755,7 @@ describe('65c02', function() {
         it('BBR1 should not branch if bit 1 set', function() {
             initMemory([[0x00, 0x33, [0x02]]]);
             testCode([0x1F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1775,7 +1763,7 @@ describe('65c02', function() {
         it('BBR2 should not branch if bit 2 set', function() {
             initMemory([[0x00, 0x33, [0x04]]]);
             testCode([0x2F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1783,7 +1771,7 @@ describe('65c02', function() {
         it('BBR3 should not branch if bit 3 set', function() {
             initMemory([[0x00, 0x33, [0x08]]]);
             testCode([0x3F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1791,7 +1779,7 @@ describe('65c02', function() {
         it('BBR4 should not branch if bit 4 set', function() {
             initMemory([[0x00, 0x33, [0x10]]]);
             testCode([0x4F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1799,7 +1787,7 @@ describe('65c02', function() {
         it('BBR5 should not branch if bit 5 set', function() {
             initMemory([[0x00, 0x33, [0x20]]]);
             testCode([0x5F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1807,7 +1795,7 @@ describe('65c02', function() {
         it('BBR6 should not branch if bit 6 set', function() {
             initMemory([[0x00, 0x33, [0x40]]]);
             testCode([0x6F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1815,7 +1803,7 @@ describe('65c02', function() {
         it('BBR7 should not branch if bit 7 set', function() {
             initMemory([[0x00, 0x33, [0x80]]]);
             testCode([0x7F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1896,7 +1884,7 @@ describe('65c02', function() {
         it('BBS0 should not branch if bit 0 clear', function() {
             initMemory([[0x00, 0x33, [0xFE]]]);
             testCode([0x8F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1904,7 +1892,7 @@ describe('65c02', function() {
         it('BBS1 should not branch if bit 1 clear', function() {
             initMemory([[0x00, 0x33, [0xFD]]]);
             testCode([0x9F, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1912,7 +1900,7 @@ describe('65c02', function() {
         it('BBS2 should not branch if bit 2 clear', function() {
             initMemory([[0x00, 0x33, [0xFB]]]);
             testCode([0xAF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1920,7 +1908,7 @@ describe('65c02', function() {
         it('BBS3 should not branch if bit 3 clear', function() {
             initMemory([[0x00, 0x33, [0xF7]]]);
             testCode([0xBF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1928,7 +1916,7 @@ describe('65c02', function() {
         it('BBS4 should not branch if bit 4 clear', function() {
             initMemory([[0x00, 0x33, [0xEF]]]);
             testCode([0xCF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1936,7 +1924,7 @@ describe('65c02', function() {
         it('BBS5 should not branch if bit 5 clear', function() {
             initMemory([[0x00, 0x33, [0xDF]]]);
             testCode([0xDF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1944,7 +1932,7 @@ describe('65c02', function() {
         it('BBS6 should not branch if bit 6 clear', function() {
             initMemory([[0x00, 0x33, [0xBF]]]);
             testCode([0xEF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });
@@ -1952,7 +1940,7 @@ describe('65c02', function() {
         it('BBS7 should not branch if bit 7 clear', function() {
             initMemory([[0x00, 0x33, [0x7B]]]);
             testCode([0xFF, 0x33, 0x7F], 1, {}, {
-                cycles: 5,
+                cycles: 6,
                 pc: 0x0403
             });
         });

--- a/test/util/cpu.ts
+++ b/test/util/cpu.ts
@@ -1,0 +1,36 @@
+import { flags } from 'js/cpu6502';
+import type { CpuState } from 'js/cpu6502';
+import type { byte } from 'js/types';
+import { toHex } from 'js/util';
+
+const detail = !!process.env.JEST_DETAIL;
+
+export function toReadableFlags(sr: byte) {
+    return [
+        ((sr & flags.N) ? 'N' : '-'),
+        ((sr & flags.V) ? 'V' : '-'),
+        ((sr & flags.X) ? 'X' : '-'),
+        ((sr & flags.B) ? 'B' : '-'),
+        ((sr & flags.D) ? 'D' : '-'),
+        ((sr & flags.I) ? 'I' : '-'),
+        ((sr & flags.Z) ? 'Z' : '-'),
+        ((sr & flags.C) ? 'C' : '-')
+    ].join('');
+}
+
+export function toReadableState(state: CpuState) {
+    if (detail) {
+        const { pc, sp, a, x, y, s } = state;
+
+        return {
+            pc: toHex(pc, 4),
+            sp: toHex(sp),
+            a: toHex(a),
+            x: toHex(x),
+            y: toHex(y),
+            s: toReadableFlags(s)
+        };
+    } else {
+        return state;
+    }
+}

--- a/test/util/memory.ts
+++ b/test/util/memory.ts
@@ -1,8 +1,11 @@
-import { MemoryPages, byte } from '../../js/types';
+import { MemoryPages, byte, word } from 'js/types';
 import { assertByte } from './asserts';
 
+export type Log = [address: word, value: byte, types: 'read'|'write']
 export class TestMemory implements MemoryPages {
     private data: Buffer;
+    private logging: boolean = false;
+    private log: Log[] = [];
 
     constructor(private size: number) {
         this.data = Buffer.alloc(size << 8);
@@ -20,7 +23,11 @@ export class TestMemory implements MemoryPages {
         assertByte(page);
         assertByte(off);
 
-        return this.data[(page << 8) | off];
+        const val = this.data[(page << 8) | off];
+        if (this.logging) {
+            this.log.push([page << 8 | off, val, 'read']);
+        }
+        return val;
     }
 
     write(page: byte, off: byte, val: byte) {
@@ -28,10 +35,27 @@ export class TestMemory implements MemoryPages {
         assertByte(off);
         assertByte(val);
 
+        if (this.logging) {
+            this.log.push([page << 8 | off, val, 'write']);
+        }
         this.data[(page << 8) | off] = val;
     }
 
     reset() {
+        this.log = [];
+    }
+
+    logStart() {
+        this.log = [];
+        this.logging = true;
+    }
+
+    logStop() {
+        this.logging = false;
+    }
+
+    getLog() {
+        return this.log;
     }
 }
 


### PR DESCRIPTION
A test data set was published at https://github.com/TomHarte/ProcessorTests which contain cycle traces of instructions for various versions of the 6502.

This adds a test harness that reads those data files, and adjusts the CPU6502 behavior to match the behavior of the vanilla and WDC 65C02 test data.

Also converts the existing CPU tests to Typescript, and fixes any inconsistencies that came up from the new behaviors.