### PR TITLE
Clean up copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2019 Will Scullin
+Copyright (c) 2010-2021 Will Scullin and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/apple2js.html
+++ b/apple2js.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
+ Copyright 2010-2021 Will Scullin and contributors
 
  Permission to use, copy, modify, distribute, and sell this software and its
  documentation for any purpose is hereby granted without fee, provided that

--- a/apple2jse.html
+++ b/apple2jse.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
+ Copyright 2010-2021 Will Scullin and contributors
 
  Permission to use, copy, modify, distribute, and sell this software and its
  documentation for any purpose is hereby granted without fee, provided that

--- a/css/apple2.css
+++ b/css/apple2.css
@@ -1,5 +1,3 @@
-/* Copyright 2010-2019 Will Scullin */
-
 #header {
   width: 580px;
   margin: auto;

--- a/js/apple2io.ts
+++ b/js/apple2io.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import CPU6502 from './cpu6502';
 import { Card, Memory, MemoryPages, TapeData, byte, Restorable } from './types';
 import { debug, garbage } from './util';

--- a/js/canvas.ts
+++ b/js/canvas.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { byte, Color, memory, MemoryPages, rom } from './types';
 import { allocMemPages } from './util';
 import {

--- a/js/cards/cffa.ts
+++ b/js/cards/cffa.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import type { byte, Card, Restorable } from '../types';
 import { debug, toHex } from '../util';
 import { rom as readOnlyRom } from '../roms/cards/cffa';

--- a/js/cards/disk2.ts
+++ b/js/cards/disk2.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { base64_encode} from '../base64';
 import type {
     byte,

--- a/js/cards/langcard.ts
+++ b/js/cards/langcard.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import RAM, { RAMState } from '../ram';
 import { debug } from '../util';
 import { Card, Memory, byte, Restorable } from '../types';

--- a/js/cards/nsc.js
+++ b/js/cards/nsc.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug } from '../util';
 
 export default function NoSlotClock(rom)

--- a/js/cards/parallel.ts
+++ b/js/cards/parallel.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug } from '../util';
 import { Card, Restorable, byte } from '../types';
 import { rom } from '../roms/cards/parallel';

--- a/js/cards/ramfactor.ts
+++ b/js/cards/ramfactor.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { allocMem, debug } from '../util';
 import { Card, Restorable, byte, memory } from '../types';
 import { rom } from '../roms/cards/ramfactor';

--- a/js/cards/smartport.ts
+++ b/js/cards/smartport.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug, toHex } from '../util';
 import { rom as smartPortRom } from '../roms/cards/smartport';
 import { Card, Restorable, byte, word, rom } from '../types';

--- a/js/cards/thunderclock.ts
+++ b/js/cards/thunderclock.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug, toHex } from '../util';
 import { Card, Restorable, byte } from '../types';
 import { rom } from '../roms/cards/thunderclock';

--- a/js/cards/videoterm.ts
+++ b/js/cards/videoterm.ts
@@ -1,14 +1,3 @@
-/* Copyright 2017 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { allocMemPages, debug } from '../util';
 import { Card, Restorable, byte, Color, memory, word } from '../types';
 import { ROM, VIDEO_ROM } from '../roms/cards/videoterm';

--- a/js/cpu6502.ts
+++ b/js/cpu6502.ts
@@ -1,15 +1,3 @@
-/*
- * Copyright 2010-2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { Memory, MemoryPages, byte, word } from './types';
 import { debug, toHex } from './util';
 

--- a/js/formats/2mg.ts
+++ b/js/formats/2mg.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import DOS from './do';
 import Nibble from './nib';
 import ProDOS from './po';

--- a/js/formats/block.ts
+++ b/js/formats/block.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { DiskOptions, BlockDisk, ENCODING_BLOCK } from './types';
 
 /**

--- a/js/formats/d13.ts
+++ b/js/formats/d13.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { explodeSector13, D13O } from './format_utils';
 import { NibbleDisk, DiskOptions, ENCODING_NIBBLE } from './types';
 

--- a/js/formats/do.ts
+++ b/js/formats/do.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { explodeSector16, DO } from './format_utils';
 import { bytify } from '../util';
 import { byte } from '../types';

--- a/js/formats/format_utils.ts
+++ b/js/formats/format_utils.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { bit, byte, memory } from '../types';
 import { base64_decode, base64_encode } from '../base64';
 import { bytify, debug, toHex } from '../util';

--- a/js/formats/nib.ts
+++ b/js/formats/nib.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { NibbleDisk, DiskOptions, ENCODING_NIBBLE } from './types';
 import { memory } from '../types';
 

--- a/js/formats/po.ts
+++ b/js/formats/po.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { explodeSector16, PO } from './format_utils';
 import { bytify } from '../util';
 import type { byte } from '../types';

--- a/js/formats/prodos/bit_map.js
+++ b/js/formats/prodos/bit_map.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 export function BitMap(volume) {
     var vdh = volume.vdh();
     var blocks = volume.blocks();

--- a/js/formats/prodos/constants.js
+++ b/js/formats/prodos/constants.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 export var BLOCK_SIZE = 512;
 
 export var STORAGE_TYPES = {

--- a/js/formats/prodos/directory.js
+++ b/js/formats/prodos/directory.js
@@ -1,15 +1,4 @@
 
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { dateToUint32, readFileName, writeFileName, uint32ToDate } from './utils';
 import { readEntries, writeEntries } from './file_entry';
 import { STORAGE_TYPES, ACCESS_TYPES } from './constants';

--- a/js/formats/prodos/file_entry.js
+++ b/js/formats/prodos/file_entry.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { dateToUint32, readFileName, writeFileName, uint32ToDate } from './utils';
 import { STORAGE_TYPES, ACCESS_TYPES } from './constants';
 

--- a/js/formats/prodos/index.js
+++ b/js/formats/prodos/index.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { VDH } from './vdh';
 import { BitMap } from './bit_map';
 

--- a/js/formats/prodos/sapling_file.js
+++ b/js/formats/prodos/sapling_file.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { BLOCK_SIZE, STORAGE_TYPES } from './constants';
 
 export function SaplingFile (volume, fileEntry) {

--- a/js/formats/prodos/seedling_file.js
+++ b/js/formats/prodos/seedling_file.js
@@ -1,13 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
 import { STORAGE_TYPES } from './constants';
 
 export function SeedlingFile (volume, fileEntry) {

--- a/js/formats/prodos/tree_file.js
+++ b/js/formats/prodos/tree_file.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { BLOCK_SIZE, STORAGE_TYPES } from './constants';
 
 export function TreeFile (volume, fileEntry) {

--- a/js/formats/prodos/utils.js
+++ b/js/formats/prodos/utils.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug } from '../../util';
 import { STORAGE_TYPES } from './constants';
 import { Directory } from './directory';

--- a/js/formats/prodos/vdh.js
+++ b/js/formats/prodos/vdh.js
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { dateToUint32, readFileName, writeFileName, uint32ToDate } from './utils';
 import { readEntries, writeEntries } from './file_entry';
 import { STORAGE_TYPES, ACCESS_TYPES } from './constants';

--- a/js/formats/types.ts
+++ b/js/formats/types.ts
@@ -1,14 +1,3 @@
-/* Copyright 2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import type { byte, memory, MemberOf } from '../types';
 import type { GamepadConfiguration } from '../ui/types';
 

--- a/js/formats/woz.ts
+++ b/js/formats/woz.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug, toHex } from '../util';
 import { bit, byte, word } from '../types';
 import { grabNibble } from './format_utils';

--- a/js/gl.ts
+++ b/js/gl.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { byte, Color, memory, MemoryPages, rom } from './types';
 import { allocMemPages } from './util';
 

--- a/js/mmu.ts
+++ b/js/mmu.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import CPU6502 from './cpu6502';
 import RAM, { RAMState } from './ram';
 import ROM, { ROMState } from './roms/rom';

--- a/js/prefs.ts
+++ b/js/prefs.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 const havePrefs = typeof window.localStorage !== 'undefined';
 
 export default class Prefs {

--- a/js/ram.ts
+++ b/js/ram.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { byte, memory, Memory, Restorable } from './types';
 import { allocMemPages } from './util';
 

--- a/js/ui/audio.ts
+++ b/js/ui/audio.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { BOOLEAN_OPTION, OptionHandler } from './options_modal';
 import Apple2IO from '../apple2io';
 import { debug } from '../util';

--- a/js/ui/audio_worker.ts
+++ b/js/ui/audio_worker.ts
@@ -1,14 +1,3 @@
-/* Copyright 2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 declare global {
     interface AudioWorkletProcessor {
         readonly port: MessagePort;

--- a/js/ui/gamepad.ts
+++ b/js/ui/gamepad.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import Apple2IO from '../apple2io';
 import { BUTTON, ButtonType, GamepadConfiguration } from './types';
 

--- a/js/ui/keyboard.ts
+++ b/js/ui/keyboard.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { byte, DeepMemberOf, KnownKeys } from '../types';
 import Apple2IO from '../apple2io';
 import CPU6502 from '../cpu6502';

--- a/js/ui/printer.ts
+++ b/js/ui/printer.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { byte } from '../types';
 
 /**

--- a/js/ui/tape.ts
+++ b/js/ui/tape.ts
@@ -1,15 +1,4 @@
 
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { TapeData } from '../types';
 import Apple2IO from '../apple2io';
 import { debug } from '../util';

--- a/js/ui/types.ts
+++ b/js/ui/types.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import type { KnownKeys } from '../types';
 
 export const BUTTON = {

--- a/js/util.ts
+++ b/js/util.ts
@@ -1,14 +1,3 @@
-/* Copyright 2010-2019 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided ' as is'  without express or
- * implied warranty.
- */
-
 import { byte, memory, word } from './types';
 
 /*eslint no-console: 0*/

--- a/workers/format.worker.ts
+++ b/workers/format.worker.ts
@@ -1,14 +1,3 @@
-/* Copyright 2021 Will Scullin <scullin@scullinsteel.com>
- *
- * Permission to use, copy, modify, distribute, and sell this software and its
- * documentation for any purpose is hereby granted without fee, provided that
- * the above copyright notice appear in all copies and that both that
- * copyright notice and this permission notice appear in supporting
- * documentation.  No representations are made about the suitability of this
- * software for any purpose.  It is provided "as is" without express or
- * implied warranty.
- */
-
 import { debug } from '../js/util';
 import { jsonDecode } from '../js/formats/format_utils';
 import {


### PR DESCRIPTION
Remove copyright notice from all files except the top level HTML and license files. They were an interesting artifact for tracking when files were introduced and updated but git does a better job and I had gotten very sloppy about adding them to new files, and not all files were added by me, anyway.