### PR TITLE
Add the recommended eslint plugins for TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,9 @@
     "extends": [
         "eslint:recommended",
         "plugin:react/recommended",
-        "plugin:react-hooks/recommended"
+        "plugin:react-hooks/recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
     "overrides": [
         {

--- a/js/apple2.ts
+++ b/js/apple2.ts
@@ -28,7 +28,7 @@ import RAM, { RAMState } from './ram';
 import SYMBOLS from './symbols';
 import Debugger, { DebuggerContainer } from './debugger';
 
-import { Restorable, rom } from './types';
+import { ReadonlyUint8Array, Restorable, rom } from './types';
 import { processGamepad } from './ui/gamepad';
 
 export interface Apple2Options {
@@ -47,7 +47,7 @@ export interface Stats {
     renderedFrames: number;
 }
 
-interface State {
+export interface State {
     cpu: CpuState;
     vm: VideoModesState;
     io: Apple2IOState;
@@ -91,8 +91,8 @@ export class Apple2 implements Restorable<State>, DebuggerContainer {
     }
 
     async init(options: Apple2Options) {
-        const romImportPromise = import(`./roms/system/${options.rom}`);
-        const characterRomImportPromise = import(`./roms/character/${options.characterRom}`);
+        const romImportPromise = import(`./roms/system/${options.rom}`) as Promise<{ default: new () => ROM }>;
+        const characterRomImportPromise = import(`./roms/character/${options.characterRom}`) as Promise<{ default: ReadonlyUint8Array }>;
 
         const LoresPage = options.gl ? LoresPageGL : LoresPage2D;
         const HiresPage = options.gl ? HiresPageGL : HiresPage2D;

--- a/js/apple2io.ts
+++ b/js/apple2io.ts
@@ -52,7 +52,7 @@ const LOC = {
 };
 
 export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> {
-    private _slot: Array<Card | null> = new Array(7).fill(null);
+    private _slot: Array<Card | null> = new Array<Card | null>(7).fill(null);
     private _auxRom: Memory | null = null;
 
     private _khz = 1023;
@@ -82,7 +82,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
 
     private _tape: TapeData = [];
     private _tapeOffset = 0;
-    private _tapeNext: number = 0;
+    private _tapeNext = 0;
     private _tapeCurrent = false;
 
     constructor(private readonly cpu: CPU6502, private readonly vm: VideoModes) {
@@ -106,7 +106,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
                 if (this._audioListener) {
                     this._audioListener(this._sample);
                 }
-                this._sample = new Array(this._sample_size);
+                this._sample = new Array<number>(this._sample_size);
                 this._sampleIdx = 0;
             }
         }
@@ -226,7 +226,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
                     this._tapeCurrent = this._tape[this._tapeOffset][1];
                     while (now >= this._tapeNext) {
                         if ((this._tapeOffset % 1000) === 0) {
-                            debug('Read ' + (this._tapeOffset / 1000));
+                            debug(`Read ${this._tapeOffset / 1000}`);
                         }
                         this._tapeCurrent = this._tape[this._tapeOffset][1];
                         this._tapeNext += this._tape[this._tapeOffset++][0];
@@ -326,7 +326,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
     }
 
     read(page: byte, off: byte) {
-        let result: number = 0;
+        let result = 0;
         let slot;
         let card;
 
@@ -451,7 +451,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
     }
 
     setTape(tape: TapeData) {
-        debug('Tape length: ' + tape.length);
+        debug(`Tape length: ${tape.length}`);
         this._tape = tape;
         this._tapeOffset = -1;
     }
@@ -459,7 +459,7 @@ export default class Apple2IO implements MemoryPages, Restorable<Apple2IOState> 
     sampleRate(rate: number, sample_size: number) {
         this._rate = rate;
         this._sample_size = sample_size;
-        this._sample = new Array(this._sample_size);
+        this._sample = new Array<number>(this._sample_size);
         this._sampleIdx = 0;
         this._calcSampleRate();
     }

--- a/js/base64.ts
+++ b/js/base64.ts
@@ -124,7 +124,7 @@ export function base64_decode(data: string | null | undefined): memory | undefin
 
 const DATA_URL_PREFIX = 'data:application/octet-stream;base64,';
 
-export function base64_json_parse(json: string) {
+export function base64_json_parse(json: string): unknown {
     const reviver = (_key: string, value: unknown) => {
         if (typeof value ==='string' && value.startsWith(DATA_URL_PREFIX)) {
             return base64_decode(value.slice(DATA_URL_PREFIX.length));

--- a/js/canvas.ts
+++ b/js/canvas.ts
@@ -494,7 +494,7 @@ export class HiresPage2D implements HiresPage {
     oneSixtyMode: boolean;
     mixedDHRMode: boolean;
     monoDHRMode: boolean;
-    colorDHRMode: boolean = true;
+    colorDHRMode = true;
 
     constructor(
         private vm: VideoModes,
@@ -843,7 +843,7 @@ export class VideoModes2D implements VideoModes {
     private _canvas: HTMLCanvasElement;
     private _left: number;
     private _top: number;
-    private _refreshFlag: boolean = true;
+    private _refreshFlag = true;
 
     public ready = Promise.resolve();
 

--- a/js/cards/disk2.ts
+++ b/js/cards/disk2.ts
@@ -308,7 +308,7 @@ function setDriveState(state: DriveState) {
 /**
  * Emulates the 16-sector and 13-sector versions of the Disk ][ drive and controller.
  */
-export default class DiskII implements Card {
+export default class DiskII implements Card<State> {
 
     private drives: Drive[] = [
         {   // Drive 1
@@ -346,7 +346,7 @@ export default class DiskII implements Card {
     /** Q6 (Shift/Load): Used by WOZ disks. */
     private q6 = 0;
     /** Q7 (Read/Write): Used by WOZ disks. */
-    private q7: boolean = false;
+    private q7 = false;
     /** Q7 (Read/Write): Used by Nibble disks. */
     private writeMode = false;
     /** Whether the selected drive is on. */
@@ -412,7 +412,7 @@ export default class DiskII implements Card {
             this.cur.rawTracks[this.cur.trackMap[this.cur.track]] || [0];
 
         while (workCycles-- > 0) {
-            let pulse: number = 0;
+            let pulse = 0;
             if (this.clock === 4) {
                 pulse = track[this.cur.head];
                 if (!pulse) {
@@ -488,7 +488,7 @@ export default class DiskII implements Card {
             return;
         }
         if (this.on && (this.skip || this.writeMode)) {
-            const track = this.cur.tracks![this.cur.track >> 2];
+            const track = this.cur.tracks[this.cur.track >> 2];
             if (track && track.length) {
                 if (this.cur.head >= track.length) {
                     this.cur.head = 0;
@@ -520,7 +520,7 @@ export default class DiskII implements Card {
      * tracks by activating two neighboring coils at once.
      */
     private setPhase(phase: Phase, on: boolean) {
-        this.debug('phase ' + phase + (on ? ' on' : ' off'));
+        this.debug(`phase ${phase}${on ? ' on' : ' off'}`);
         if (on) {
             this.cur.track += PHASE_DELTA[this.cur.phase][phase] * 2;
             this.cur.phase = phase;
@@ -682,7 +682,7 @@ export default class DiskII implements Card {
         } else {
             // It's not explicitly stated, but writes to any address set the
             // data register.
-            this.bus = val!;
+            this.bus = val;
         }
 
         return result;
@@ -703,7 +703,9 @@ export default class DiskII implements Card {
         return this.bootstrapRom[off];
     }
 
-    write() { }
+    write() {
+        // not writable
+    }
 
     reset() {
         if (this.on) {
@@ -722,7 +724,7 @@ export default class DiskII implements Card {
         this.moveHead();
     }
 
-    getState() {
+    getState(): State {
         const result = {
             drives: [] as DriveState[],
             skip: this.skip,
@@ -803,7 +805,7 @@ export default class DiskII implements Card {
         return false;
     }
 
-    getJSON(drive: DriveNumber, pretty: boolean = false) {
+    getJSON(drive: DriveNumber, pretty = false) {
         const cur = this.drives[drive - 1];
         if (!isNibbleDrive(cur)) {
             throw new Error('Can\'t save WOZ disks to JSON');

--- a/js/cards/langcard.ts
+++ b/js/cards/langcard.ts
@@ -141,7 +141,7 @@ export default class LanguageCard implements Card, Restorable<LanguageCardState>
     }
 
     read(page: byte, off: byte): byte {
-        let result: number = 0;
+        let result = 0;
         if (page < 0xe0) {
             result = this.read1.read(page, off);
         } else {

--- a/js/cards/mouse.ts
+++ b/js/cards/mouse.ts
@@ -217,7 +217,9 @@ export default class Mouse implements Card, Restorable<MouseState> {
         return rom[off];
     }
 
-    write() {}
+    write() {
+        // not writable
+    }
 
     /**
      * Triggers interrupts based on activity since the last tick

--- a/js/cards/nsc.ts
+++ b/js/cards/nsc.ts
@@ -12,7 +12,7 @@ const A2 = 0x04;
 export default class NoSlotClock {
     bits: bit[] = [];
     pattern = new Array(64);
-    patternIdx: number = 0;
+    patternIdx = 0;
 
     constructor(private rom: ROM) {
         debug('NoSlotClock');
@@ -110,6 +110,7 @@ export default class NoSlotClock {
     }
 
     setState(_: unknown) {
+        // Setting the state makes no sense.
     }
 }
 

--- a/js/cards/parallel.ts
+++ b/js/cards/parallel.ts
@@ -6,7 +6,8 @@ const LOC = {
     IOREG: 0x80
 } as const;
 
-export interface ParallelState {}
+export type ParallelState = Record<string, never>;
+
 export interface ParallelOptions {
     putChar: (val: byte) => void;
 }
@@ -37,11 +38,15 @@ export default class Parallel implements Card, Restorable<ParallelState> {
         return rom[off];
     }
 
-    write() {}
+    write() {
+        // not writable
+    }
 
     getState() {
         return {};
     }
 
-    setState(_state: ParallelState) {}
+    setState(_state: ParallelState) {
+        // can't set the state
+    }
 }

--- a/js/cards/ramfactor.ts
+++ b/js/cards/ramfactor.ts
@@ -126,7 +126,9 @@ export default class RAMFactor implements Card, Restorable<RAMFactorState> {
         return rom[this.firmware << 12 | (page - 0xC0) << 8 | off];
     }
 
-    write() {}
+    write() {
+        // not writable
+    }
 
     reset() {
         this.firmware = 0;

--- a/js/cards/smartport.ts
+++ b/js/cards/smartport.ts
@@ -197,9 +197,9 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
      */
 
     readBlock(state: CpuState, drive: number, block: number, buffer: Address) {
-        this.debug('read drive=' + drive);
-        this.debug('read buffer=' + buffer);
-        this.debug('read block=$' + toHex(block));
+        this.debug(`read drive=${drive}`);
+        this.debug(`read buffer=${buffer.toString()}`);
+        this.debug(`read block=$${toHex(block)}`);
 
         if (!this.disks[drive]?.blocks.length) {
             debug('Drive', drive, 'is empty');
@@ -224,9 +224,9 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
      */
 
     writeBlock(state: CpuState, drive: number, block: number, buffer: Address) {
-        this.debug('write drive=' + drive);
-        this.debug('write buffer=' + buffer);
-        this.debug('write block=$' + toHex(block));
+        this.debug(`write drive=${drive}`);
+        this.debug(`write buffer=${buffer.toString()}`);
+        this.debug(`write block=$${toHex(block)}`);
 
         if (!this.disks[drive]?.blocks.length) {
             debug('Drive', drive, 'is empty');
@@ -332,11 +332,11 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
             buffer = bufferAddr.readAddress();
             block = blockAddr.readWord();
 
-            this.debug('cmd=' + cmd);
+            this.debug(`cmd=${cmd}`);
             this.debug('unit=$' + toHex(unit));
 
-            this.debug('slot=' + driveSlot + ' drive=' + drive);
-            this.debug('buffer=' + buffer + ' block=$' + toHex(block));
+            this.debug(`slot=${driveSlot} drive=${drive}`);
+            this.debug(`buffer=${buffer.toString()} block=$${toHex(block)}`);
 
             switch (cmd) {
                 case 0: // INFO
@@ -362,14 +362,14 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
 
             const retVal = stackAddr.readAddress();
 
-            this.debug('return=' + retVal);
+            this.debug(`return=${retVal.toString()}`);
 
             const cmdBlockAddr = retVal.inc(1);
             cmd = cmdBlockAddr.readByte();
             const cmdListAddr = cmdBlockAddr.inc(1).readAddress();
 
-            this.debug('cmd=' + cmd);
-            this.debug('cmdListAddr=' + cmdListAddr);
+            this.debug(`cmd=${cmd}`);
+            this.debug(`cmdListAddr=${cmdListAddr.toString()}`);
 
             stackAddr.writeAddress(retVal.inc(3));
 
@@ -378,13 +378,13 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
             buffer = cmdListAddr.inc(2).readAddress();
             let status;
 
-            this.debug('parameterCount=' + parameterCount);
+            this.debug(`parameterCount=${parameterCount}`);
             switch (cmd) {
                 case 0x00: // INFO
                     status = cmdListAddr.inc(4).readByte();
-                    this.debug('info unit=' + unit);
-                    this.debug('info buffer=' + buffer);
-                    this.debug('info status=' + status);
+                    this.debug(`info unit=${unit}`);
+                    this.debug(`info buffer=${buffer.toString()}`);
+                    this.debug(`info status=${status}`);
                     switch (unit) {
                         case 0:
                             switch (status) {
@@ -482,6 +482,7 @@ export default class SmartPort implements Card, MassStorage, Restorable<SmartPor
     }
 
     write() {
+        // not writable
     }
 
     getState() {

--- a/js/cards/thunderclock.ts
+++ b/js/cards/thunderclock.ts
@@ -20,7 +20,7 @@ const FLAGS = {
     STROBE: 0x04
 } as const;
 
-export interface ThunderclockState {}
+export type ThunderclockState = Record<string, never>;
 
 export default class Thunderclock implements Card, Restorable<ThunderclockState>
 {
@@ -138,6 +138,7 @@ export default class Thunderclock implements Card, Restorable<ThunderclockState>
     }
 
     write() {
+        // not writable
     }
 
     ioSwitch(off: byte, val?: byte) {
@@ -148,5 +149,7 @@ export default class Thunderclock implements Card, Restorable<ThunderclockState>
         return {};
     }
 
-    setState() {}
+    setState(_state: ThunderclockState) {
+        // can't set the state
+    }
 }

--- a/js/components/Apple2.tsx
+++ b/js/components/Apple2.tsx
@@ -45,7 +45,7 @@ export const Apple2 = (props: Apple2Props) => {
         if (screen.current) {
             const options = {
                 canvas: screen.current,
-                tick: () => {},
+                tick: () => { /* do nothing */ },
                 ...props,
             };
             const apple2 = new Apple2Impl(options);

--- a/js/components/Drives.tsx
+++ b/js/components/Drives.tsx
@@ -46,7 +46,9 @@ export const Drives = ({ io, sectors }: DrivesProps) => {
                     side,
                 }));
             },
-            dirty: () => {}
+            dirty: () => {
+                // do nothing
+            }
         };
 
         if (io) {

--- a/js/components/FileChooser.tsx
+++ b/js/components/FileChooser.tsx
@@ -26,7 +26,7 @@ export interface FileChooserProps {
     control?: typeof controlDefault;
 }
 
-const hasPicker: boolean = !!window.showOpenFilePicker;
+const hasPicker = !!window.showOpenFilePicker;
 const controlDefault = hasPicker ? 'picker' : 'input';
 
 interface InputFileChooserProps {
@@ -41,7 +41,7 @@ interface ExtraProps {
 
 const InputFileChooser = ({
     disabled = false,
-    onChange = () => { },
+    onChange = () => { /* do nothing */ },
     accept = [],
 }: InputFileChooserProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
@@ -104,33 +104,35 @@ interface FilePickerChooserProps {
 
 const FilePickerChooser = ({
     disabled = false,
-    onChange = () => { },
+    onChange = () => { /* do nothing */ },
     accept = [ACCEPT_EVERYTHING_TYPE]
 }: FilePickerChooserProps) => {
     const [busy, setBusy] = useState<boolean>(false);
     const [selectedFilename, setSelectedFilename] = useState<string>();
     const fileHandlesRef = useRef<FileSystemFileHandle[]>();
 
-    const onClickInternal = useCallback(async () => {
+    const onClickInternal = useCallback(() => {
         if (busy) {
             return;
         }
         setBusy(true);
-        try {
-            const pickedFiles = await window.showOpenFilePicker({
-                multiple: false,
-                excludeAcceptAllOption: true,
-                types: accept,
-            });
-            if (fileHandlesRef.current !== pickedFiles) {
-                fileHandlesRef.current = pickedFiles;
-                onChange(pickedFiles);
+        (async () => {
+            try {
+                const pickedFiles = await window.showOpenFilePicker({
+                    multiple: false,
+                    excludeAcceptAllOption: true,
+                    types: accept,
+                });
+                if (fileHandlesRef.current !== pickedFiles) {
+                    fileHandlesRef.current = pickedFiles;
+                    onChange(pickedFiles);
+                }
+            } catch (e: unknown) {
+                console.error(e);
+            } finally {
+                setBusy(false);
             }
-        } catch (e: unknown) {
-            console.error(e);
-        } finally {
-            setBusy(false);
-        }
+        })().catch(console.error);
     }, [accept, busy, onChange]);
 
     useEffect(() => {

--- a/js/components/FileModal.tsx
+++ b/js/components/FileModal.tsx
@@ -52,20 +52,20 @@ export const FileModal = ({ disk2, number, onClose, isOpen }: FileModalProps) =>
 
     const doCancel = useCallback(() => onClose(true), [onClose]);
 
-    const doOpen = useCallback(async () => {
+    const doOpen = useCallback(() => {
         const hashParts = getHashParts();
 
         if (disk2 && handles && handles.length === 1) {
             hashParts[number] = '';
             setBusy(true);
-            try {
-                await loadLocalFile(disk2, number, await handles[0].getFile());
-            } catch (e) {
-                console.error(e);
-            } finally {
-                setBusy(false);
-                onClose();
-            }
+            (async () => {
+                try {
+                    await loadLocalFile(disk2, number, await handles[0].getFile());
+                    onClose();
+                } finally {
+                    setBusy(false);
+                }
+            })().catch(console.error);
         }
 
         if (disk2 && filename) {

--- a/js/components/util/files.ts
+++ b/js/components/util/files.ts
@@ -82,7 +82,7 @@ export const loadJSON = async (disk2: DiskII, number: DriveNumber, url: string) 
     if (!response.ok) {
         throw new Error(`Error loading: ${response.statusText}`);
     }
-    const data: JSONDisk = await response.json();
+    const data = await response.json() as JSONDisk;
     if (!includes(NIBBLE_FORMATS, data.type)) {
         throw new Error(`Type ${data.type} not recognized.`);
     }
@@ -112,7 +112,10 @@ export const loadHttpFile = async (
     if (!response.ok) {
         throw new Error(`Error loading: ${response.statusText}`);
     }
-    const reader = response.body!.getReader();
+    if (!response.body) {
+        throw new Error('Error loading: no body');
+    }
+    const reader = response.body.getReader();
     let received = 0;
     const chunks: Uint8Array[] = [];
 
@@ -131,7 +134,7 @@ export const loadHttpFile = async (
     }
 
     const urlParts = url.split('/');
-    const file = urlParts.pop()!;
+    const file = urlParts.pop() || url;
     const fileParts = file.split('.');
     const ext = fileParts.pop()?.toLowerCase() || '[none]';
     const name = decodeURIComponent(fileParts.join('.'));

--- a/js/cpu6502.ts
+++ b/js/cpu6502.ts
@@ -135,7 +135,7 @@ function isResettablePageHandler(pageHandler: MemoryPages | ResettablePageHandle
 
 const BLANK_PAGE: Memory = {
     read: function () { return 0; },
-    write: function () { }
+    write: function () { /* not writable */ }
 };
 
 interface Opts {
@@ -196,7 +196,7 @@ export default class CPU6502 {
     private addr: word = 0;
 
     /** Filled array of memory handlers by address page */
-    private memPages: Memory[] = new Array(0x100);
+    private memPages: Memory[] = new Array<Memory>(0x100);
     /** Callbacks invoked on reset signal */
     private resetHandlers: ResettablePageHandler[] = [];
     /** Elapsed cycles */
@@ -246,7 +246,7 @@ export default class CPU6502 {
         }
 
         // Certain browsers benefit from using arrays over maps
-        this.opary = new Array(0x100);
+        this.opary = new Array<Instruction>(0x100);
 
         for (let idx = 0; idx < 0x100; idx++) {
             this.opary[idx] = ops[idx] || this.unknown(idx);

--- a/js/debugger.ts
+++ b/js/debugger.ts
@@ -128,7 +128,7 @@ export default class Debugger {
 
         result += this.padWithSymbol(pc);
 
-        const cmd = new Array(size);
+        const cmd = new Array<number>(size);
         for (let idx = 0, jdx = pc; idx < size; idx++, jdx++) {
             cmd[idx] = this.cpu.read(jdx);
         }
@@ -238,13 +238,13 @@ export default class Debugger {
             case 'implied':
                 break;
             case 'immediate':
-                result += '#' + toHexOrSymbol(lsb);
+                result += `#${toHexOrSymbol(lsb)}`;
                 break;
             case 'absolute':
-                result += '' + toHexOrSymbol(addr, 4);
+                result += `${toHexOrSymbol(addr, 4)}`;
                 break;
             case 'zeroPage':
-                result += '' + toHexOrSymbol(lsb);
+                result += `${toHexOrSymbol(lsb)}`;
                 break;
             case 'relative':
                 {
@@ -253,38 +253,38 @@ export default class Debugger {
                         off -= 256;
                     }
                     pc += off + 2;
-                    result += '' + toHexOrSymbol(pc, 4) + ' (' + off + ')';
+                    result += `${toHexOrSymbol(pc, 4)} (${off})`;
                 }
                 break;
             case 'absoluteX':
-                result += '' + toHexOrSymbol(addr, 4)+ ',X';
+                result += `${toHexOrSymbol(addr, 4)},X`;
                 break;
             case 'absoluteY':
-                result += '' + toHexOrSymbol(addr, 4) + ',Y';
+                result += `${toHexOrSymbol(addr, 4)},Y`;
                 break;
             case 'zeroPageX':
-                result += '' + toHexOrSymbol(lsb) + ',X';
+                result += `${toHexOrSymbol(lsb)},X`;
                 break;
             case 'zeroPageY':
-                result += '' + toHexOrSymbol(lsb) + ',Y';
+                result += `${toHexOrSymbol(lsb)},Y`;
                 break;
             case 'absoluteIndirect':
-                result += '(' + toHexOrSymbol(addr, 4) + ')';
+                result += `(${toHexOrSymbol(addr, 4)})`;
                 break;
             case 'zeroPageXIndirect':
-                result += '(' + toHexOrSymbol(lsb) + ',X)';
+                result += `(${toHexOrSymbol(lsb)},X)`;
                 break;
             case 'zeroPageIndirectY':
-                result += '(' + toHexOrSymbol(lsb) + '),Y';
+                result += `(${toHexOrSymbol(lsb)},),Y`;
                 break;
             case 'accumulator':
                 result += 'A';
                 break;
             case 'zeroPageIndirect':
-                result += '(' + toHexOrSymbol(lsb) + ')';
+                result += `(${toHexOrSymbol(lsb)})`;
                 break;
             case 'absoluteXIndirect':
-                result += '(' + toHexOrSymbol(addr, 4) + ',X)';
+                result += `(${toHexOrSymbol(addr, 4)},X)`;
                 break;
             case 'zeroPage_relative':
                 val = lsb;
@@ -293,7 +293,7 @@ export default class Debugger {
                     off -= 256;
                 }
                 pc += off + 2;
-                result += '' + toHexOrSymbol(val) + ',' + toHexOrSymbol(pc, 4) + ' (' + off + ')';
+                result += `${toHexOrSymbol(val)},${toHexOrSymbol(pc, 4)} (${off})`;
                 break;
             default:
                 break;

--- a/js/entry.tsx
+++ b/js/entry.tsx
@@ -1,4 +1,5 @@
 import { h, render } from 'preact';
 import { App } from './components/App';
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 render(<App />, document.getElementById('app')!);

--- a/js/formats/format_utils.ts
+++ b/js/formats/format_utils.ts
@@ -1,7 +1,7 @@
 import { bit, byte, memory } from '../types';
 import { base64_decode, base64_encode } from '../base64';
 import { bytify, debug, toHex } from '../util';
-import { NibbleDisk, ENCODING_NIBBLE } from './types';
+import { NibbleDisk, ENCODING_NIBBLE, JSONDisk } from './types';
 
 /**
  * DOS 3.3 Physical sector order (index is physical sector, value is DOS sector).
@@ -465,14 +465,14 @@ export function jsonEncode(disk: NibbleDisk, pretty: boolean): string {
 
 export function jsonDecode(data: string): NibbleDisk {
     const tracks: memory[] = [];
-    const json = JSON.parse(data);
-    const v = json.volume;
-    const readOnly = json.readOnly;
+    const json = JSON.parse(data) as JSONDisk;
+    const v = json.volume || 254;
+    const readOnly = json.readOnly || false;
     for (let t = 0; t < json.data.length; t++) {
         let track: byte[] = [];
         for (let s = 0; s < json.data[t].length; s++) {
             const _s = json.type === 'po' ? PO[s] : DO[s];
-            const sector: string = json.data[t][_s];
+            const sector: string = json.data[t][_s] as string;
             const d = base64_decode(sector);
             track = track.concat(explodeSector16(v, t, s, d));
         }

--- a/js/formats/prodos/directory.ts
+++ b/js/formats/prodos/directory.ts
@@ -33,7 +33,7 @@ export class Directory {
     prev: word = 0;
     next: word = 0;
     storageType: byte = STORAGE_TYPES.DIRECTORY;
-    name: string = 'Untitled';
+    name = 'Untitled';
     creation: Date = new Date();
     access: byte = ACCESS_TYPES.ALL;
     entryLength = 0x27;

--- a/js/formats/prodos/file_entry.ts
+++ b/js/formats/prodos/file_entry.ts
@@ -28,11 +28,11 @@ export class FileEntry {
     offset: word;
 
     storageType: byte = STORAGE_TYPES.SEEDLING;
-    name: string = 'Untitled';
+    name = 'Untitled';
     fileType: byte = 0;
     auxType: word = 0;
     blocksUsed: word = 0;
-    eof: number = 0;
+    eof = 0;
     access: byte = ACCESS_TYPES.ALL;
     creation: Date = new Date();
     lastMod: Date = new Date();

--- a/js/formats/prodos/vdh.ts
+++ b/js/formats/prodos/vdh.ts
@@ -30,7 +30,7 @@ export class VDH {
     prev: word = 0;
     next: word = 0;
     storageType: byte = STORAGE_TYPES.VDH_HEADER;
-    name: string = '';
+    name = '';
     creation: Date = new Date();
     access: byte = ACCESS_TYPES.ALL;
     entryLength = 0x27;

--- a/js/formats/woz.ts
+++ b/js/formats/woz.ts
@@ -22,7 +22,7 @@ function stringFromBytes(data: DataView, start: number, end: number): string {
     return String.fromCharCode.apply(
         null,
         new Uint8Array(data.buffer.slice(data.byteOffset + start, data.byteOffset + end))
-    );
+    ) as string;
 }
 
 export class InfoChunk {

--- a/js/main2.ts
+++ b/js/main2.ts
@@ -51,6 +51,7 @@ switch (romVersion) {
 }
 
 const options = {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     canvas: document.querySelector<HTMLCanvasElement>('#screen')!,
     gl: prefs.readPref('gl_canvas', 'true') === 'true',
     rom,

--- a/js/main2e.ts
+++ b/js/main2e.ts
@@ -42,6 +42,7 @@ switch (romVersion) {
 
 const options = {
     gl: prefs.readPref('gl_canvas', 'true') === 'true',
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     canvas: document.querySelector<HTMLCanvasElement>('#screen')!,
     rom,
     characterRom,

--- a/js/mmu.ts
+++ b/js/mmu.ts
@@ -525,19 +525,19 @@ export default class MMU implements Memory, Restorable<MMUState> {
 
         switch(off) {
             case LOC.BSRBANK2:
-                this._debug('Bank 2 Read ' + !this._bank1);
+                this._debug(`Bank 2 Read ${!this._bank1 ? 'true' : 'false'}`);
                 result = !this._bank1 ? 0x80 : 0x00;
                 break;
             case LOC.BSRREADRAM:
-                this._debug('Bank SW RAM Read ' + this._readbsr);
+                this._debug(`Bank SW RAM Read ${this._readbsr ? 'true' : 'false'}`);
                 result = this._readbsr ? 0x80 : 0x00;
                 break;
             case LOC.RAMRD: // 0xC013
-                this._debug('Aux RAM Read ' + this._auxRamRead);
+                this._debug(`Aux RAM Read ${this._auxRamRead ? 'true' : 'false'}`);
                 result = this._auxRamRead ? 0x80 : 0x0;
                 break;
             case LOC.RAMWRT: // 0xC014
-                this._debug('Aux RAM Write ' + this._auxRamWrite);
+                this._debug(`Aux RAM Write ${this._auxRamWrite ? 'true' : 'false'}`);
                 result = this._auxRamWrite ? 0x80 : 0x0;
                 break;
             case LOC.INTCXROM: // 0xC015
@@ -545,15 +545,15 @@ export default class MMU implements Memory, Restorable<MMUState> {
                 result = this._intcxrom ? 0x80 : 0x00;
                 break;
             case LOC.ALTZP: // 0xC016
-                this._debug('Alt ZP ' + this._altzp);
+                this._debug(`Alt ZP ${this._altzp ? 'true' : 'false'}`);
                 result = this._altzp ? 0x80 : 0x0;
                 break;
             case LOC.SLOTC3ROM: // 0xC017
-                this._debug('Slot C3 ROM ' + this._slot3rom);
+                this._debug(`Slot C3 ROM ${this._slot3rom ? 'true' : 'false'}`);
                 result = this._slot3rom ? 0x80 : 0x00;
                 break;
             case LOC._80STORE: // 0xC018
-                this._debug('80 Store ' + this._80store);
+                this._debug(`80 Store ${this._80store ? 'true' : 'false'}`);
                 result = this._80store ? 0x80 : 0x00;
                 break;
             case LOC.VERTBLANK: // 0xC019

--- a/js/roms/rom.ts
+++ b/js/roms/rom.ts
@@ -5,10 +5,10 @@ export type ROMState = null;
 export default class ROM implements MemoryPages, Restorable<ROMState> {
 
     constructor(
-    private readonly startPage: byte,
-    private readonly endPage: byte,
-    private readonly rom: rom) {
-        const expectedLength = (endPage-startPage+1) * 256;
+        private readonly startPage: byte,
+        private readonly endPage: byte,
+        private readonly rom: rom) {
+        const expectedLength = (endPage - startPage + 1) * 256;
         if (rom.length !== expectedLength) {
             throw Error(`rom does not have the correct length: expected ${expectedLength} was ${rom.length}`);
         }
@@ -24,10 +24,12 @@ export default class ROM implements MemoryPages, Restorable<ROMState> {
         return this.rom[(page - this.startPage) << 8 | off];
     }
     write() {
+        // not writable
     }
     getState() {
         return null;
     }
-    setState(_state: null) {
+    setState(_state: ROMState) {
+        // not restorable
     }
 }

--- a/js/types.ts
+++ b/js/types.ts
@@ -86,7 +86,7 @@ export interface MemoryPages extends Memory {
 }
 
 /* An interface card */
-export interface Card extends Memory, Restorable {
+export interface Card<StateT = unknown> extends Memory, Restorable<StateT> {
     /* Reset the card */
     reset?(): void;
 

--- a/js/ui/apple2.ts
+++ b/js/ui/apple2.ts
@@ -1,3 +1,8 @@
+/*
+ * The functions in this file rely on the DOM to have certain elements
+ * and checking each time is cumbersome and not useful.
+ */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import MicroModal from 'micromodal';
 
 import { base64_json_parse, base64_json_stringify } from '../base64';
@@ -23,7 +28,7 @@ import ApplesoftDump from '../applesoft/decompiler';
 import ApplesoftCompiler from '../applesoft/compiler';
 
 import { debug } from '../util';
-import { Apple2, Stats } from '../apple2';
+import { Apple2, Stats, State as Apple2State } from '../apple2';
 import DiskII from '../cards/disk2';
 import CPU6502 from '../cpu6502';
 import { VideoModes } from '../videomodes';
@@ -123,7 +128,7 @@ export function openSave(driveString: string, event: MouseEvent) {
     const a = document.querySelector<HTMLAnchorElement>('#local_save_link')!;
 
     if (!data) {
-        alert('No data from drive ' + drive);
+        alert(`No data from drive ${drive}`);
         return;
     }
 
@@ -211,7 +216,7 @@ function loadingProgress(current: number, total: number) {
         const meter = document.querySelector<HTMLDivElement>('#loading-modal .meter')!;
         const progress = document.querySelector<HTMLDivElement>('#loading-modal .progress')!;
         meter.style.display = 'block';
-        progress.style.width = current / total * meter.clientWidth + 'px';
+        progress.style.width = `${current / total * meter.clientWidth}px`;
     }
 }
 
@@ -236,13 +241,13 @@ export function loadAjax(drive: DriveNumber, url: string) {
         }
     }).then(function (data: JSONDisk | JSONBinaryImage) {
         if (data.type === 'binary') {
-            loadBinary(data as JSONBinaryImage);
+            loadBinary(data );
         } else if (includes(DISK_FORMATS, data.type)) {
             loadDisk(drive, data);
         }
         initGamepad(data.gamepad);
         loadingStop();
-    }).catch(function (error) {
+    }).catch(function (error: Error) {
         loadingStop();
         openAlert(error.message);
         console.error(error);
@@ -414,7 +419,7 @@ export function doLoadHTTP(drive: DriveNumber, url?: string) {
     if (url) {
         fetch(url).then(function (response) {
             if (response.ok) {
-                const reader = response!.body!.getReader();
+                const reader = response.body!.getReader();
                 let received = 0;
                 const chunks: Uint8Array[] = [];
                 const contentLength = parseInt(response.headers.get('content-length')!, 10);
@@ -468,7 +473,7 @@ export function doLoadHTTP(drive: DriveNumber, url?: string) {
                 throw new Error(`Extension ${ext} not recognized.`);
             }
             loadingStop();
-        }).catch(function (error) {
+        }).catch((error: Error) => {
             loadingStop();
             openAlert(error.message);
             console.error(error);
@@ -499,19 +504,19 @@ export function updateKHz() {
         case 0: {
             delta = cycles - lastCycles;
             khz = Math.trunc(delta / ms);
-            kHzElement.innerText = khz + ' kHz';
+            kHzElement.innerText = `${khz} kHz`;
             break;
         }
         case 1: {
             delta = stats.renderedFrames - lastRenderedFrames;
             fps = Math.trunc(delta / (ms / 1000));
-            kHzElement.innerText = fps + ' rps';
+            kHzElement.innerText = `${fps} rps`;
             break;
         }
         default: {
             delta = stats.frames - lastFrames;
             fps = Math.trunc(delta / (ms / 1000));
-            kHzElement.innerText = fps + ' fps';
+            kHzElement.innerText = `${fps} fps`;
         }
     }
 
@@ -579,7 +584,7 @@ export function selectCategory() {
             const file = cat[idx];
             let name = file.name;
             if (file.disk) {
-                name += ' - ' + file.disk;
+                name += ` - ${file.disk}`;
             }
             const option = document.createElement('option');
             option.value = file.filename;
@@ -622,7 +627,7 @@ function loadDisk(drive: DriveNumber, disk: JSONDisk) {
  */
 
 function updateLocalStorage() {
-    const diskIndex = JSON.parse(window.localStorage.diskIndex || '{}');
+    const diskIndex = JSON.parse(window.localStorage.diskIndex as string || '{}') as LocalDiskIndex;
     const names = Object.keys(diskIndex);
 
     const cat: DiskDescriptor[] = disk_categories['Local Saves'] = [];
@@ -654,7 +659,7 @@ type LocalDiskIndex = {
 };
 
 function saveLocalStorage(drive: DriveNumber, name: string) {
-    const diskIndex = JSON.parse(window.localStorage.diskIndex || '{}') as LocalDiskIndex;
+    const diskIndex = JSON.parse(window.localStorage.diskIndex as string || '{}') as LocalDiskIndex;
 
     const json = _disk2.getJSON(drive);
     diskIndex[name] = json;
@@ -667,7 +672,7 @@ function saveLocalStorage(drive: DriveNumber, name: string) {
 }
 
 function deleteLocalStorage(name: string) {
-    const diskIndex = JSON.parse(window.localStorage.diskIndex || '{}') as LocalDiskIndex;
+    const diskIndex = JSON.parse(window.localStorage.diskIndex as string || '{}') as LocalDiskIndex;
     if (diskIndex[name]) {
         delete diskIndex[name];
         openAlert('Deleted');
@@ -677,7 +682,7 @@ function deleteLocalStorage(name: string) {
 }
 
 function loadLocalStorage(drive: DriveNumber, name: string) {
-    const diskIndex = JSON.parse(window.localStorage.diskIndex || '{}') as LocalDiskIndex;
+    const diskIndex = JSON.parse(window.localStorage.diskIndex as string || '{}') as LocalDiskIndex;
     if (diskIndex[name]) {
         _disk2.setJSON(drive, diskIndex[name]);
         driveLights.label(drive, name);
@@ -891,7 +896,7 @@ function onLoaded(apple2: Apple2, disk2: DiskII, massStorage: MassStorage, print
     });
     keyboard.setFunction('F9', () => {
         if (window.localStorage.state) {
-            _apple2.setState(base64_json_parse(window.localStorage.state));
+            _apple2.setState(base64_json_parse(window.localStorage.state as string) as Apple2State);
         }
     });
 

--- a/js/ui/audio_worker.ts
+++ b/js/ui/audio_worker.ts
@@ -12,13 +12,17 @@ declare global {
     function registerProcessor(name: string, ctor :{ new(): AudioWorkletProcessor }): void;
 }
 
+export interface AppleAudioMessageEvent extends MessageEvent {
+    data: Float32Array;
+}
+
 export class AppleAudioProcessor extends AudioWorkletProcessor {
     private samples: Float32Array[] = [];
 
     constructor() {
         super();
         console.info('AppleAudioProcessor constructor');
-        this.port.onmessage = (ev: MessageEvent) => {
+        this.port.onmessage = (ev: AppleAudioMessageEvent) => {
             this.samples.push(ev.data);
             if (this.samples.length > 256) {
                 this.samples.shift();

--- a/js/ui/drive_lights.ts
+++ b/js/ui/drive_lights.ts
@@ -3,11 +3,12 @@ import type { DriveNumber } from '../formats/types';
 
 export default class DriveLights implements Callbacks {
     public driveLight(drive: DriveNumber, on: boolean) {
-        const disk =
-            document.querySelector('#disk' + drive)! as HTMLElement;
-        disk.style.backgroundImage =
-            on ? 'url(css/red-on-16.png)' :
-                'url(css/red-off-16.png)';
+        const disk = document.querySelector<HTMLElement>(`#disk${drive}`);
+        if (disk) {
+            disk.style.backgroundImage =
+                on ? 'url(css/red-on-16.png)' :
+                    'url(css/red-off-16.png)';
+        }
     }
 
     public dirty(_drive: DriveNumber, _dirty: boolean) {
@@ -15,11 +16,11 @@ export default class DriveLights implements Callbacks {
     }
 
     public label(drive: DriveNumber, label?: string, side?: string) {
-        const labelElement =
-            document.querySelector('#disk-label' + drive)! as HTMLElement;
-        if (label) {
-            labelElement.innerText = label + (side ? ` - ${side}` : '');
+        const labelElement = document.querySelector<HTMLElement>(`#disk-label${drive}`);
+        const labelText = `${label || ''} ${(side ? `- ${side}` : '')}`;
+        if (label && labelElement) {
+            labelElement.innerText = labelText;
         }
-        return labelElement.innerText;
+        return labelText;
     }
 }

--- a/js/ui/gamepad.ts
+++ b/js/ui/gamepad.ts
@@ -58,7 +58,7 @@ export function processGamepad(io: Apple2IO) {
                 if (val <= 0) {
                     io.buttonDown(-val as 0 | 1 | 2);
                 } else {
-                    io.keyDown(gamepadMap[idx]!);
+                    io.keyDown(val);
                 }
             } else if (!pressed && old) {
                 if (val <= 0) {

--- a/js/ui/joystick.ts
+++ b/js/ui/joystick.ts
@@ -93,6 +93,7 @@ export class JoyStick implements OptionHandler {
             return;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const s = document.querySelector<HTMLDivElement>('#screen')!;
         const offset = s.getBoundingClientRect();
         let x = (evt.pageX - offset.left) / s.clientWidth;

--- a/js/ui/keyboard.ts
+++ b/js/ui/keyboard.ts
@@ -272,12 +272,13 @@ export default class KeyBoard {
     }
 
     controlKey(down: boolean) {
-        const ctrlKey = this.kb.querySelector('.key-CTRL');
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const ctrlKey = this.kb.querySelector('.key-CTRL')!;
         this.controlled = down;
         if (down) {
-            ctrlKey!.classList.add('active');
+            ctrlKey.classList.add('active');
         } else {
-            ctrlKey!.classList.remove('active');
+            ctrlKey.classList.remove('active');
         }
     }
 
@@ -319,7 +320,8 @@ export default class KeyBoard {
      *     otherwise the used state is set to true.
      */
     capslockKey(down?: boolean | undefined) {
-        const capsLock = this.kb.querySelector('.key-LOCK');
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const capsLock = this.kb.querySelector('.key-LOCK')!;
 
         if (arguments.length === 0) {
             if (this.capslockKeyUsed) {
@@ -335,9 +337,9 @@ export default class KeyBoard {
         }
 
         if (this.capslocked) {
-            capsLock!.classList.add('active');
+            capsLock.classList.add('active');
         } else {
-            capsLock!.classList.remove('active');
+            capsLock.classList.remove('active');
         }
     }
 
@@ -348,6 +350,7 @@ export default class KeyBoard {
     }
 
     create(el: string) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.kb = document.querySelector(el)!;
         let x, y, row, key, label, label1, label2;
 
@@ -362,7 +365,7 @@ export default class KeyBoard {
         for (y = 0; y < 5; y++) {
             row = document.createElement('div');
             row.classList.add('row');
-            row.classList.add('row' + y);
+            row.classList.add(`row${y}`);
             this.kb.append(row);
             for (x = 0; x < this.keys[0][y].length; x++) {
                 const key1 = this.keys[0][y][x];

--- a/js/ui/printer.ts
+++ b/js/ui/printer.ts
@@ -24,6 +24,7 @@ export default class Printer {
      * @param {string} el The selector of the element on which to bind the "paper".
      */
     constructor(el: string) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.paper = document.querySelector(el)!;
         this.newLine();
     }

--- a/js/ui/screen.ts
+++ b/js/ui/screen.ts
@@ -19,6 +19,7 @@ export class Screen implements OptionHandler {
     constructor(private vm: VideoModes) {}
 
     enterFullScreen = () => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const elem = document.getElementById('screen')!;
         if (document.fullscreenEnabled) {
             if (document.fullscreenElement) {

--- a/js/ui/tape.ts
+++ b/js/ui/tape.ts
@@ -32,8 +32,8 @@ export default class Tape {
                 let old = (datum > 0.0), current;
                 let last = 0;
                 let delta: number;
-                debug('Sample Count: ' + data.length);
-                debug('Sample rate: ' + buffer.sampleRate);
+                debug(`Sample Count: ${data.length}`);
+                debug(`Sample rate: ${buffer.sampleRate}`);
                 for (let idx = 1; idx < data.length; idx++) {
                     datum = data[idx];
                     if ((datum > 0.1) || (datum < -0.1)) {
@@ -65,7 +65,7 @@ export default class Tape {
                 if (done) {
                     done();
                 }
-            }, function (error) {
+            }, (error: Error) => {
                 window.alert(error.message);
             });
         };

--- a/js/util.ts
+++ b/js/util.ts
@@ -46,7 +46,7 @@ export function bytify(ary: number[]): memory {
 
 /** Writes to the console. */
 export function debug(...args: unknown[]): void {
-    console.log.apply(console, args);
+    console.log(...args);
 }
 
 /**

--- a/js/videomodes.ts
+++ b/js/videomodes.ts
@@ -41,9 +41,7 @@ export interface LoresPage extends VideoPage {
     getText: () => string;
 }
 
-export interface HiresPage extends VideoPage {
-
-}
+export type HiresPage = VideoPage;
 
 export interface VideoModes extends Restorable<VideoModesState> {
     textMode: boolean;

--- a/test/components/FileChooser.spec.tsx
+++ b/test/components/FileChooser.spec.tsx
@@ -23,6 +23,8 @@ const FAKE_FILE_HANDLE = {
     isDirectory: false,
 } as const;
 
+const NOP = () => { /* do nothing */ };
+
 // eslint-disable-next-line no-undef
 const EMPTY_FILE_LIST = backdoors.newFileList();
 
@@ -31,13 +33,13 @@ const FAKE_FILE = new File([], 'fake');
 describe('FileChooser', () => {
     describe('input-based chooser', () => {
         it('should be instantiable', () => {
-            const { container } = render(<FileChooser control='input' onChange={() => { }} />);
+            const { container } = render(<FileChooser control='input' onChange={NOP} />);
 
             expect(container).not.toBeNull();
         });
 
         it('should use the file input element', async () => {
-            render(<FileChooser control='input' onChange={() => { }} />);
+            render(<FileChooser control='input' onChange={NOP} />);
 
             const inputElement = await screen.findByRole('button') as HTMLInputElement;
             expect(inputElement.type).toBe('file');
@@ -89,7 +91,7 @@ describe('FileChooser', () => {
         });
 
         it('should be instantiable', () => {
-            const { container } = render(<FileChooser control='picker' onChange={() => { }} />);
+            const { container } = render(<FileChooser control='picker' onChange={NOP} />);
 
             expect(container).not.toBeNull();
         });

--- a/test/env/jsdom-with-backdoors.js
+++ b/test/env/jsdom-with-backdoors.js
@@ -8,6 +8,12 @@
  * "better" because it does all of the dirty work during environment
  * setup. It still requires typing.
  */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 const JsdomEnvironment = require('jest-environment-jsdom');
 

--- a/test/js/__mocks__/apple2shader.js
+++ b/test/js/__mocks__/apple2shader.js
@@ -11,7 +11,7 @@ export const screenEmu = (function () {
         DisplayConfiguration: class {},
         Point: class {},
         ScreenView: class {
-            initOpenGL() {}
+            initOpenGL() { return Promise.resolve(); }
         },
         Size: class{},
     };

--- a/test/js/formats/create_disk.spec.ts
+++ b/test/js/formats/create_disk.spec.ts
@@ -11,7 +11,7 @@ describe('createDiskFromJsonDisk', () => {
             readOnly: undefined,
             side: 'Front',
             volume: 254,
-            tracks: expect.any(Array)
+            tracks: expect.any(Array) as number[][]
         });
     });
 });

--- a/test/js/formats/testdata/woz.ts
+++ b/test/js/formats/testdata/woz.ts
@@ -1,3 +1,4 @@
+import { byte } from 'js/types';
 import {
     numberToBytes,
     stringToBytes,
@@ -49,7 +50,7 @@ const mockInfo2 = [
  * Track map all pointing to track 0
  */
 
-export const mockTMAP = new Array(160);
+export const mockTMAP = new Array<byte>(160);
 mockTMAP.fill(0);
 
 /**
@@ -58,7 +59,7 @@ mockTMAP.fill(0);
 
 // 24 bits of track data, padded
 
-const mockTrackData = new Array(6646);
+const mockTrackData = new Array<byte>(6646);
 mockTrackData.fill(0);
 mockTrackData[0] = 0xd5;
 mockTrackData[1] = 0xaa;
@@ -82,7 +83,7 @@ const mockTRKS = [
  * Version 2 TRKS structure
  */
 
-const mockTrackMap = new Array(160 * 8);
+const mockTrackMap = new Array<byte>(160 * 8);
 mockTrackMap.fill(0);
 mockTrackMap[0x00] = 0x03;
 mockTrackMap[0x01] = 0x00;
@@ -93,7 +94,7 @@ mockTrackMap[0x07] = 0x00;
 mockTrackMap[0x08] = 0x00;
 mockTrackMap[0x09] = 0x00;
 
-const mockTrackData2 = new Array(512);
+const mockTrackData2 = new Array<byte>(512);
 mockTrackData2.fill(0);
 mockTrackData2[0] = 0xd5;
 mockTrackData2[1] = 0xaa;

--- a/test/js/formats/util.ts
+++ b/test/js/formats/util.ts
@@ -1,6 +1,6 @@
 import { memory } from 'js/types';
 
-export function skipGap(track: memory, start: number = 0): number {
+export function skipGap(track: memory, start = 0): number {
     const end = start + 0x100; // no gap is this big
     let i = start;
     while (i < end && track[i] === 0xFF) {
@@ -24,12 +24,12 @@ export function compareSequences(track: memory, bytes: number[], pos: number): b
 export function expectSequence(track: memory, pos: number, bytes: number[]): number {
     if (!compareSequences(track, bytes, pos)) {
         const track_slice = track.slice(pos, Math.min(track.length, pos + bytes.length));
-        fail(`expected ${bytes} got ${track_slice}`);
+        fail(`expected ${bytes.toString()} got ${track_slice.toString()}`);
     }
     return pos + bytes.length;
 }
 
-export function findBytes(track: memory, bytes: number[], start: number = 0): number {
+export function findBytes(track: memory, bytes: number[], start = 0): number {
     if (start + bytes.length > track.length) {
         return -1;
     }
@@ -50,7 +50,7 @@ export function findBytes(track: memory, bytes: number[], start: number = 0): nu
  * @param padLength padded length
  * @returns an array of bytes
  */
-export const stringToBytes = (val: string, pad: string = '\0', padLength: number = 0) => {
+export const stringToBytes = (val: string, pad = '\0', padLength = 0) => {
     const result = [];
     let idx = 0;
     while (idx < val.length) {

--- a/test/js/formats/woz.spec.ts
+++ b/test/js/formats/woz.spec.ts
@@ -1,4 +1,4 @@
-import { WozDisk, ENCODING_BITSTREAM } from 'js/formats/types';
+import { ENCODING_BITSTREAM } from 'js/formats/types';
 import createDiskFromWoz from 'js/formats/woz';
 import {
     mockWoz1,
@@ -19,7 +19,7 @@ describe('woz', () => {
             rawData: mockWoz1
         };
 
-        const disk = createDiskFromWoz(options) as WozDisk;
+        const disk = createDiskFromWoz(options) ;
         expect(disk).toEqual({
             name: 'Mock Woz 1',
             readOnly: true,
@@ -58,7 +58,7 @@ describe('woz', () => {
             rawData: mockWoz2
         };
 
-        const disk = createDiskFromWoz(options) as WozDisk;
+        const disk = createDiskFromWoz(options) ;
         expect(disk).toEqual({
             name: 'Mock Woz 2',
             side: 'B',

--- a/test/util/bios.ts
+++ b/test/util/bios.ts
@@ -23,6 +23,7 @@ export class Program implements MemoryPages {
     }
 
     write(_page: byte, _off: byte, _val: byte) {
+        // do nothing
     }
 }
 

--- a/test/util/image.ts
+++ b/test/util/image.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 export const createImageFromImageData = (data: ImageData) => {
     const canvas = document.createElement('canvas');
     canvas.width = data.width;

--- a/test/util/memory.ts
+++ b/test/util/memory.ts
@@ -4,7 +4,7 @@ import { assertByte } from './asserts';
 export type Log = [address: word, value: byte, types: 'read'|'write'];
 export class TestMemory implements MemoryPages {
     private data: Buffer;
-    private logging: boolean = false;
+    private logging = false;
     private log: Log[] = [];
 
     constructor(private size: number) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const { merge } = require('webpack-merge');
 


### PR DESCRIPTION
This adds both the recommended TypeScript checks, plus the recommended
TypeScript checks that require type checking.  This latter addition
means that eslint essentially has to compile all of the TypeScript in
the project, causing it to be slower. This isn't much of a problem in
VS Code because there's a lot of caching being done, but it's clearly
slower when run on the commandline.

All of the errors are either fixed or suppressed.  Some errors are
suppressed because fixing them would be too laborious for the little
value gained.  Others are caused by some overly-zealous matching that
requires a config refactoring to fix.