### PR TITLE
Implement `FileSystemFileHandle` for file input

### DIFF
--- a/js/components/FileModal.tsx
+++ b/js/components/FileModal.tsx
@@ -7,9 +7,9 @@ import DiskII from '../cards/disk2';
 import { ErrorModal } from './ErrorModal';
 
 import index from 'json/disks/index.json';
-import { FileChooser, FilePickerAcceptType, FileSystemFileHandleLike } from './FileChooser';
 import { noAwait } from './util/promises';
 import { useHash } from './hooks/useHash';
+import { FileChooser, FilePickerAcceptType } from './FileChooser';
 
 const DISK_TYPES: FilePickerAcceptType[] = [
     {
@@ -50,7 +50,7 @@ export const FileModal = ({ disk2, number, onClose, isOpen }: FileModalProps) =>
     const [busy, setBusy] = useState<boolean>(false);
     const [empty, setEmpty] = useState<boolean>(true);
     const [category, setCategory] = useState<string>();
-    const [handles, setHandles] = useState<FileSystemFileHandleLike[]>();
+    const [handles, setHandles] = useState<FileSystemFileHandle[]>();
     const [filename, setFilename] = useState<string>();
     const [error, setError] = useState<unknown>();
     const hash = useHash();
@@ -82,7 +82,7 @@ export const FileModal = ({ disk2, number, onClose, isOpen }: FileModalProps) =>
         setHashParts(hashParts);
     }, [disk2, filename, number, onClose, handles, hash]);
 
-    const onChange = useCallback((handles: FileSystemFileHandleLike[]) => {
+    const onChange = useCallback((handles: FileSystemFileHandle[]) => {
         setEmpty(handles.length === 0);
         setHandles(handles);
     }, []);

--- a/test/components/FileChooser.spec.tsx
+++ b/test/components/FileChooser.spec.tsx
@@ -69,9 +69,9 @@ describe('FileChooser', () => {
                 const handle = handleList[0];
                 expect(handle.kind).toBe('file');
                 expect(handle.name).toBe(FAKE_FILE.name);
-                expect(handle.isWritable).toBe(false);
                 await expect(handle.getFile()).resolves.toBe(FAKE_FILE);
                 await expect(handle.createWritable()).rejects.toEqual('File not writable.');
+                await expect(handle.queryPermission({ mode: 'readwrite' })).resolves.toBe('denied');
             });
         });
     });
@@ -125,7 +125,6 @@ describe('FileChooser', () => {
                 const handle = handleList[0];
                 expect(handle.kind).toBe(FAKE_FILE_HANDLE.kind);
                 expect(handle.name).toBe(FAKE_FILE_HANDLE.name);
-                expect(handle.isWritable).toBe(true);
             });
         });
     });


### PR DESCRIPTION
This removes the `FileSystemFileHandleLike` interface in preference to
just implementing the correct interface. The advantage of the
`FileSystemFileHandle` interface is that it can be passed to the
worker directly to load the file.