### PR TITLE
Add `spawn` as a way of calling promise-returning blocks

### DIFF
--- a/js/components/Apple2.tsx
+++ b/js/components/Apple2.tsx
@@ -13,7 +13,7 @@ import { Screen } from './Screen';
 import { Drives } from './Drives';
 import { Slinky } from './Slinky';
 import { ThunderClock } from './ThunderClock';
-import { noAwait, Ready } from './util/promises';
+import { spawn, Ready } from './util/promises';
 
 import styles from './css/Apple2.module.css';
 
@@ -55,7 +55,7 @@ export const Apple2 = (props: Apple2Props) => {
                 ...props,
             };
             const apple2 = new Apple2Impl(options);
-            noAwait((async () => {
+            spawn(async () => {
                 try {
                     await apple2.ready;
                     setApple2(apple2);
@@ -67,7 +67,7 @@ export const Apple2 = (props: Apple2Props) => {
                 } catch (e) {
                     setError(e);
                 }
-            }))();
+            });
         }
     }, [props, drivesReady]);
 

--- a/js/components/util/promises.ts
+++ b/js/components/util/promises.ts
@@ -12,6 +12,14 @@ export function noAwait<F extends (...args: unknown[]) => Promise<unknown>>(f: F
 }
 
 /**
+ * Calls the given `Promise`-returning function and returns void, signalling that it is
+ * explicitly not awaited.
+ */
+export function spawn(f: () => Promise<unknown>): void {
+    noAwait(f)();
+}
+
+/**
  * Utility class that allows a promise to be passed to a
  * service to be resolved.
  */


### PR DESCRIPTION
This change adds `spawn` which takes a no-argument, promise-returning
function, calls it, and returns `void`.  This makes it easy to call
async blocks from `useEffect` and other places that don't take async
functions, but also makes such calls explicit.