### PR TITLE
Interruptable spawn

### DIFF
--- a/js/components/Apple2.tsx
+++ b/js/components/Apple2.tsx
@@ -55,17 +55,17 @@ export const Apple2 = (props: Apple2Props) => {
                 ...props,
             };
             const apple2 = new Apple2Impl(options);
-            return spawn(async (interrupted) => {
+            const controller = spawn(async (signal) => {
                 try {
                     await apple2.ready;
-                    if (interrupted()) {
+                    if (signal.aborted) {
                         return;
                     }
                     setApple2(apple2);
                     setIO(apple2.getIO());
                     setCPU(apple2.getCPU());
                     await drivesReady.ready;
-                    if (interrupted()) {
+                    if (signal.aborted) {
                         return;
                     }
                     apple2.reset();
@@ -74,6 +74,7 @@ export const Apple2 = (props: Apple2Props) => {
                     setError(e);
                 }
             });
+            return controller.abort();
         }
     }, [props, drivesReady]);
 

--- a/js/components/Apple2.tsx
+++ b/js/components/Apple2.tsx
@@ -55,13 +55,19 @@ export const Apple2 = (props: Apple2Props) => {
                 ...props,
             };
             const apple2 = new Apple2Impl(options);
-            spawn(async () => {
+            return spawn(async (interrupted) => {
                 try {
                     await apple2.ready;
+                    if (interrupted()) {
+                        return;
+                    }
                     setApple2(apple2);
                     setIO(apple2.getIO());
                     setCPU(apple2.getCPU());
                     await drivesReady.ready;
+                    if (interrupted()) {
+                        return;
+                    }
                     apple2.reset();
                     apple2.run();
                 } catch (e) {

--- a/js/components/Apple2.tsx
+++ b/js/components/Apple2.tsx
@@ -13,7 +13,7 @@ import { Screen } from './Screen';
 import { Drives } from './Drives';
 import { Slinky } from './Slinky';
 import { ThunderClock } from './ThunderClock';
-import { noAwait, Ready } from './util/promises';
+import { spawn, Ready } from './util/promises';
 
 import styles from './css/Apple2.module.css';
 
@@ -55,7 +55,7 @@ export const Apple2 = (props: Apple2Props) => {
                 ...props,
             };
             const apple2 = new Apple2Impl(options);
-            noAwait((async () => {
+            spawn(async () => {
                 try {
                     await apple2.ready;
                     setApple2(apple2);
@@ -67,7 +67,7 @@ export const Apple2 = (props: Apple2Props) => {
                 } catch (e) {
                     setError(e);
                 }
-            }))();
+            });
         }
     }, [props, drivesReady]);
 

--- a/js/components/util/promises.ts
+++ b/js/components/util/promises.ts
@@ -11,12 +11,6 @@ export function noAwait<F extends (...args: unknown[]) => Promise<unknown>>(f: F
     return f as NoAwait<F>;
 }
 
-/** Returns true if the spawned task should stop doing work. */
-export type Interrupted = () => boolean;
-
-/** Tells the spawned task to stop doing work. */
-export type Interrupt = () => void;
-
 /**
  * Calls the given `Promise`-returning function, `f`, and does not await
  * the result. The function `f` is passed an {@link Interrupted} function
@@ -25,10 +19,10 @@ export type Interrupt = () => void;
  * function to return `true`. This can be used in `useEffect` calls as the
  * cleanup function.
  */
-export function spawn(f: (interrupted: Interrupted) => Promise<unknown>): Interrupt {
-    let interrupted = false;
-    noAwait(f)(() => interrupted);
-    return () => { interrupted = true; };
+export function spawn(f: (abortSignal: AbortSignal) => Promise<unknown>): AbortController {
+    const abortController = new AbortController();
+    noAwait(f)(abortController.signal);
+    return abortController;
 }
 
 /**

--- a/js/components/util/promises.ts
+++ b/js/components/util/promises.ts
@@ -12,6 +12,14 @@ export function noAwait<F extends (...args: unknown[]) => Promise<unknown>>(f: F
 }
 
 /**
+ * Calls the given `Promise`-returning function and returns void, signalling that it is
+ * explicitly not awaited.
+ */
+export function spawn(f: () => Promise<unknown>): void {
+    noAwait(f)();
+}
+
+/**
  * Utility class that allows a promise to be passed to a
  * service to be resolved.
  */

--- a/test/components/util/promises.spec.ts
+++ b/test/components/util/promises.spec.ts
@@ -1,0 +1,106 @@
+/** @jest-environment jsdom */
+
+import { Ready, spawn } from 'js/components/util/promises';
+
+describe('promises', () => {
+    describe('spawn', () => {
+        it('returns an AbortController', () => {
+            const controller = spawn(() => Promise.resolve(1));
+            expect(controller).not.toBeNull();
+            expect(controller).toBeInstanceOf(AbortController);
+        });
+
+        it('passes an AbortSignal to the target function', () => {
+            let signalCapture: AbortSignal | null = null;
+            spawn((signal) => {
+                signalCapture = signal;
+                return Promise.resolve(1);
+            });
+            expect(signalCapture).not.toBeNull();
+            expect(signalCapture).toBeInstanceOf(AbortSignal);
+        });
+
+        it('has the controller hooked up to the signal', async () => {
+            let isAborted = false;
+
+            const controllerIsAborted = new Ready();
+            const spawnHasRecorded = new Ready();
+   
+            const controller = spawn(async (signal) => {
+                await controllerIsAborted.ready;
+                isAborted = signal.aborted;
+                spawnHasRecorded.onReady();
+            });
+   
+            controller.abort();
+            controllerIsAborted.onReady();
+   
+            await spawnHasRecorded.ready;
+            expect(isAborted).toBe(true);
+        });
+
+        it('allows long-runing tasks to be stopped', async () => {
+            let isFinished = false;
+
+            const innerReady = new Ready();
+            const innerFinished = new Ready();
+            
+            const controller = spawn(async (signal) => {
+                innerReady.onReady();
+                let i = 0;
+                while (!signal.aborted) {
+                    i++;
+                    await tick();
+                }
+                isFinished = true;
+                console.log(i);
+                innerFinished.onReady();
+            });
+            await innerReady.ready;
+            await tick();
+            controller.abort();
+            await innerFinished.ready;
+
+            expect(isFinished).toBe(true);
+        });
+
+        it('allows nesting via listeners', async () => {
+            let isInnerAborted = false;
+
+            const innerReady = new Ready();
+            const outerReady = new Ready();
+            const abortRecorded = new Ready();
+
+            const controller = spawn(async (signal) => {
+                const innerController = spawn(async (innerSignal) => {
+                    await innerReady.ready;
+                    isInnerAborted = innerSignal.aborted;
+                    abortRecorded.onReady();
+                });
+                // TODO(flan): Chain signal.reason when calling innerController.abort()
+                // once jsdom 19 has wider adoption (currently on 16.6.0). Likewise there
+                // are some subtle problems with signal.addEventListener that should be
+                // addressed by https://github.com/jsdom/jsdom/pull/3347.
+                // signal.addEventListener('abort', () => innerController.abort(signal.reason));
+                signal.addEventListener('abort', () => innerController.abort());
+                await outerReady.ready;
+            });
+
+            // Abort the outer controller, but don't let the outer block run.
+            controller.abort();
+            // Let the inner block run.
+            innerReady.onReady();
+            await abortRecorded.ready;
+
+            // Inner block is aborted.
+            expect(isInnerAborted).toBe(true);
+
+            // Let outer block finish.
+            outerReady.onReady();
+        });
+    });
+});
+
+function tick() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
Adds a `spawn` function to run asynchronous tasks. The task
function passed to `spawn` can take an `Interrupted` argument,
which is merely a method that returns `true` if the task should
stop doing work. Likewise, `spawn` returns an `Interrupt`
function that causes the `Interrupted` function to return `true`.

One use of `spawn` is to run asynchronous tasks from
`useEffect` blocks. The returned `Interrupt` functions can
serve as the `useEffect` cleanup function or be called from
the cleanup function.

Note that there's nothing magical about `Interrupt`—the
task must check `Interrupted` after every `await` to see
if it has been interrupted.