### PR TITLE
Make errors in the disk and audio workers not block the emulator

### DIFF
--- a/js/cards/disk2.ts
+++ b/js/cards/disk2.ts
@@ -942,25 +942,29 @@ export default class DiskII implements Card<State>, MassStorage<NibbleFormat> {
             return;
         }
 
-        this.worker = new Worker('dist/format_worker.bundle.js');
+        try {
+            this.worker = new Worker('dist/format_worker.bundle.js');
 
-        this.worker.addEventListener('message', (message: MessageEvent<FormatWorkerResponse>) => {
-            const { data } = message;
-            switch (data.type) {
-                case DISK_PROCESSED:
-                    {
-                        const { drive, disk } = data.payload;
-                        if (disk) {
-                            const cur = this.drives[drive - 1];
-                            Object.assign(cur, disk);
-                            const { name, side } = cur;
-                            this.updateDirty(drive, true);
-                            this.callbacks.label(drive, name, side);
+            this.worker.addEventListener('message', (message: MessageEvent<FormatWorkerResponse>) => {
+                const { data } = message;
+                switch (data.type) {
+                    case DISK_PROCESSED:
+                        {
+                            const { drive, disk } = data.payload;
+                            if (disk) {
+                                const cur = this.drives[drive - 1];
+                                Object.assign(cur, disk);
+                                const { name, side } = cur;
+                                this.updateDirty(drive, true);
+                                this.callbacks.label(drive, name, side);
+                            }
                         }
-                    }
-                    break;
-            }
-        });
+                        break;
+                }
+            });
+        } catch (e: unknown) {
+            console.error(e);
+        }
     }
 
     // TODO(flan): Does not work with WOZ or D13 disks

--- a/js/ui/audio.ts
+++ b/js/ui/audio.ts
@@ -37,8 +37,8 @@ export class Audio implements OptionHandler {
         });
 
         if (window.AudioWorklet) {
-            this.ready = this.audioContext.audioWorklet.addModule('./dist/audio_worker.bundle.js');
-            this.ready
+            const workletReady = this.audioContext.audioWorklet.addModule('./dist/audio_worker.bundle.js');
+            this.ready = workletReady
                 .then(() => {
                     this.workletNode = new AudioWorkletNode(this.audioContext, 'audio_worker');
 


### PR DESCRIPTION
Before, if there was an error in the audio worker or in the disk
worker, the emulator would not start. This could happen, for example,
if the page is loaded directly from disk in Chrome instead of through
a server.

Now, even if there is an error, the emulator will start.