### PR TITLE
Prevent the default action when the Apple keyboard handles a key

### DIFF
--- a/js/components/Keyboard.tsx
+++ b/js/components/Keyboard.tsx
@@ -118,9 +118,7 @@ export const Keyboard = ({ apple2, e }: KeyboardProps) => {
             if (document.activeElement && document.activeElement !== document.body) {
                 return;
             }
-            if (event.key === ' ') {
-                event.preventDefault();
-            }
+            event.preventDefault();
             const key = mapKeyEvent(event, active.includes('LOCK'));
             if (key !== 0xff) {
                 // CTRL-SHIFT-DELETE for reset


### PR DESCRIPTION
Before, if the browser window wasn't tall enough to show the whole
keyboard, using the arrow keys in the window would cause the page
to move as well.  Now all key events that are sent to the keyboard
have `preventDefault()` called on them.