### PR TITLE
Split out drivers

### DIFF
--- a/test/js/cards/disk2.spec.ts
+++ b/test/js/cards/disk2.spec.ts
@@ -66,7 +66,7 @@ describe('DiskII', () => {
 
         const state = diskII.getState();
         // These are just arbitrary changes, not an exhaustive list of fields.
-        state.skip = 1;
+        (state.drives[1].driver as {skip:number}).skip = 1;
         state.controllerState.drive = 2;
         state.controllerState.latch = 0x42;
         state.controllerState.on = true;
@@ -97,7 +97,7 @@ describe('DiskII', () => {
         expect(callbacks.label).toHaveBeenCalledWith(2, 'Disk 2', undefined);
 
         expect(callbacks.dirty).toHaveBeenCalledTimes(2);
-        expect(callbacks.dirty).toHaveBeenCalledWith(1, true);
+        expect(callbacks.dirty).toHaveBeenCalledWith(1, false);
         expect(callbacks.dirty).toHaveBeenCalledWith(2, false);
     });
 
@@ -824,7 +824,7 @@ class TestDiskReader {
 
     rawTracks() {
         // NOTE(flan): Hack to access private properties.
-        const disk = (this.diskII as unknown as { curDisk: WozDisk }).curDisk;
+        const disk = (this.diskII as unknown as { disks: WozDisk[] }).disks[1];
         const result: Uint8Array[] = [];
         for (let i = 0; i < disk.rawTracks.length; i++) {
             result[i] = disk.rawTracks[i].slice(0);


### PR DESCRIPTION
With this change, the actual logic of reading an image is moved into a "driver". The `DiskII` class still controls the state of the card, I/O, and basic drive state (like head positioning). There are three new driver classes:

* `EmptyDriver`: a do-nothing driver for empty drives. (In theory this could return random data, but currently it does nothing.)
* `NibbleDiskDriver`: a driver for dealing with simple nibble disk emulation.
* `WozDiskDriver`: a driver for WOZ disk images.

The idea is that splitting these classes apart provides better separation of concerns and, perhaps, easier testing. It will allow changing the drivers without having to worry (much) about breaking the other drivers.

Follow-on changes will put these drivers in their own files, fix up some bad naming, and improve the documentation. Feedback is welcome!

This draft PR includes the 13 sector disk support, but that has its own PR and should probably be submitted first.