### PR TITLE
Fix disk format type checks

### DIFF
--- a/js/formats/types.ts
+++ b/js/formats/types.ts
@@ -150,12 +150,12 @@ export type DiskFormat = MemberOf<typeof DISK_FORMATS>;
 
 /** Type guard for nibble disk formats. */
 export function isNibbleDiskFormat(f: DiskFormat): f is NibbleFormat {
-    return f in NIBBLE_FORMATS;
+    return NIBBLE_FORMATS.includes(f as NibbleFormat);
 }
 
 /** Type guard for block disk formats. */
 export function isBlockDiskFormat(f: DiskFormat): f is BlockFormat {
-    return f in BLOCK_FORMATS;
+    return BLOCK_FORMATS.includes(f as BlockFormat);
 }
 
 export function isNoFloppyDisk(disk: Disk): disk is NoFloppyDisk {

--- a/test/js/formats/types.spec.ts
+++ b/test/js/formats/types.spec.ts
@@ -1,0 +1,65 @@
+import {
+    isNibbleDisk,
+    isNibbleDiskFormat,
+    isBlockDiskFormat,
+    isWozDisk,
+    DiskFormat,
+    NibbleDisk,
+    WozDisk,
+} from 'js/formats/types';
+
+const nibbleDisk = {
+    encoding: 'nibble'
+} as NibbleDisk;
+
+const wozDisk = {
+    encoding: 'bitstream'
+} as WozDisk;
+
+describe('Format types', () => {
+    describe('isNibbleDisk', () => {
+        it.each([
+            [nibbleDisk, true],
+            [wozDisk, false],
+        ])('%s is %s', (disk, value) => {
+            expect(isNibbleDisk(disk)).toEqual(value);
+        });
+    });
+
+    describe('isNibbleDiskFormat', () => {
+        it.each([
+            ['2mg', true],
+            ['d13', true],
+            ['do', true],
+            ['dsk', true],
+            ['po', true],
+            ['nib', true],
+            ['hdv', false],
+        ])('%s is %s', (fmt, val) => {
+            expect(isNibbleDiskFormat(fmt as DiskFormat)).toEqual(val);
+        });
+    });
+
+    describe('isBlockDiskFormat', () => {
+        it.each([
+            ['2mg', true],
+            ['d13', false],
+            ['do', false],
+            ['dsk', false],
+            ['po', true],
+            ['nib', false],
+            ['hdv', true],
+        ])('%s is %s', (fmt, val) => {
+            expect(isBlockDiskFormat(fmt as DiskFormat)).toEqual(val);
+        });
+    });
+
+    describe('isWozDisk', () => {
+        it.each([
+            [nibbleDisk, false],
+            [wozDisk, true],
+        ])('%s is %s', (disk, value) => {
+            expect(isWozDisk(disk)).toEqual(value);
+        });
+    });
+});


### PR DESCRIPTION
Use array inclusion instead of object key check. Fixes issue identified in https://github.com/whscullin/apple2js/issues/175.