### PR TITLE
Update `@types/wicg-file-system-access`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/jest": "^29.5.2",
         "@types/jest-image-snapshot": "^4.3.1",
         "@types/micromodal": "^0.3.2",
-        "@types/wicg-file-system-access": "^2020.9.5",
+        "@types/wicg-file-system-access": "^2020.9.6",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
         "ajv": "^6.12.0",
@@ -3248,9 +3248,9 @@
       "dev": true
     },
     "node_modules/@types/wicg-file-system-access": {
-      "version": "2020.9.5",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
-      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
+      "version": "2020.9.6",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.6.tgz",
+      "integrity": "sha512-6hogE75Hl2Ov/jgp8ZhDaGmIF/q3J07GtXf8nCJCwKTHq7971po5+DId7grft09zG7plBwpF6ZU0yx9Du4/e1A==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -16964,9 +16964,9 @@
       "dev": true
     },
     "@types/wicg-file-system-access": {
-      "version": "2020.9.5",
-      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
-      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
+      "version": "2020.9.6",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.6.tgz",
+      "integrity": "sha512-6hogE75Hl2Ov/jgp8ZhDaGmIF/q3J07GtXf8nCJCwKTHq7971po5+DId7grft09zG7plBwpF6ZU0yx9Du4/e1A==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^29.5.2",
     "@types/jest-image-snapshot": "^4.3.1",
     "@types/micromodal": "^0.3.2",
-    "@types/wicg-file-system-access": "^2020.9.5",
+    "@types/wicg-file-system-access": "^2020.9.6",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "ajv": "^6.12.0",


### PR DESCRIPTION
With the latest TypeScript, there was a difference between `libdom` and `wicg-file-system-access` that caused weird errors.  Updating this fixes them.