### PR TITLE
Prevent reset getting focus

### DIFF
--- a/apple2jse.html
+++ b/apple2jse.html
@@ -101,11 +101,11 @@
           <i class="fas fa-cog"></i>
         </button>
       </div>
-      <button id="reset" type="button"
+      <div id="reset" type="button"
         onclick="Apple2.reset(event)"
         oncontextmenu="Apple2.reset(event)">
         Reset
-      </button>
+      </div>
     </div>
     <div class="inset">
       <div id="keyboard"></div>


### PR DESCRIPTION
Reset getting focus was preventing pasting from working, and since no other keys are focusable, was sort of confusing.